### PR TITLE
Use publications for all bintray configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-artifacts {
-    archives sourcesJar, javadocJar
-}
-
 publishing {
     publications {
         GnagPublication(MavenPublication) {
@@ -64,7 +60,6 @@ publishing {
 bintray {
     dryRun = false
     publish = true
-    configurations = ['archives']
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
     key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
     publications = ['GnagPublication']


### PR DESCRIPTION
### Goal(s)

Resolve the following warning observed when running `./gradlew check`:

```
$ ./gradlew check
Configuration(s) specified but the install task does not exist in project :.
:licenseMain UP-TO-DATE
:licenseTest UP-TO-DATE
:license UP-TO-DATE
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:compileTestJava UP-TO-DATE
:processTestResources UP-TO-DATE
:testClasses UP-TO-DATE
:test UP-TO-DATE
:check UP-TO-DATE

BUILD SUCCESSFUL
```
### Implementation Notes

Artifacts to be uploaded to Bintray can be defined using "Configurations" or "Maven Publications", per the [Bintray plugin docs, step 6](https://github.com/bintray/gradle-bintray-plugin). It appeared than gnag was configured both ways, which is probably unnecessary. I removed the "Configurations" config, which resolved the original warning.
