### PR TITLE
change default path to reports

### DIFF
--- a/src/main/java/com/btkelly/gnag/reporters/CheckstyleReporter.java
+++ b/src/main/java/com/btkelly/gnag/reporters/CheckstyleReporter.java
@@ -20,7 +20,7 @@ import com.btkelly.gnag.models.checkstyle.Error;
 import com.btkelly.gnag.models.checkstyle.File;
 
 /**
- * Comment reporter for Checkstyle. Looks for Checkstyle report in the default location "/build/outputs/checkstyle/checkstyle.xml"
+ * Comment reporter for Checkstyle. Looks for Checkstyle report in the default location "/build/reports/checkstyle/checkstyle.xml"
  */
 public class CheckstyleReporter extends BaseReporter<Checkstyle> {
 
@@ -60,7 +60,7 @@ public class CheckstyleReporter extends BaseReporter<Checkstyle> {
      */
     @Override
     public String getReportFilePath() {
-        return "/build/outputs/checkstyle/checkstyle.xml";
+        return "/build/reports/checkstyle/checkstyle.xml";
     }
 
     /**

--- a/src/main/java/com/btkelly/gnag/reporters/FindbugsReporter.java
+++ b/src/main/java/com/btkelly/gnag/reporters/FindbugsReporter.java
@@ -19,7 +19,7 @@ import com.btkelly.gnag.models.findbugs.BugCollection;
 import com.btkelly.gnag.models.findbugs.BugInstance;
 
 /**
- * Comment reporter for Findbugs. Looks for Findbugs report in the default location "/build/outputs/findbugs/findbugs.xml"
+ * Comment reporter for Findbugs. Looks for Findbugs report in the default location "/build/reports/findbugs/findbugs.xml"
  */
 public class FindbugsReporter extends BaseReporter<BugCollection> {
 
@@ -51,7 +51,7 @@ public class FindbugsReporter extends BaseReporter<BugCollection> {
      */
     @Override
     public String getReportFilePath() {
-        return "/build/outputs/findbugs/findbugs.xml";
+        return "/build/reports/findbugs/findbugs.xml";
     }
 
     /**

--- a/src/main/java/com/btkelly/gnag/reporters/PMDReporter.java
+++ b/src/main/java/com/btkelly/gnag/reporters/PMDReporter.java
@@ -20,7 +20,7 @@ import com.btkelly.gnag.models.pmd.Pmd;
 import com.btkelly.gnag.models.pmd.Violation;
 
 /**
- * Comment reporter for PMD. Looks for PMD report in the default location "/build/outputs/pmd/pmd.xml"
+ * Comment reporter for PMD. Looks for PMD report in the default location "/build/reports/pmd/pmd.xml"
  */
 public class PMDReporter extends BaseReporter<Pmd> {
 
@@ -62,7 +62,7 @@ public class PMDReporter extends BaseReporter<Pmd> {
      */
     @Override
     public String getReportFilePath() {
-        return "/build/outputs/pmd/pmd.xml";
+        return "/build/reports/pmd/pmd.xml";
     }
 
     /**

--- a/src/main/java/com/btkelly/gnag/tasks/CheckLocalTask.java
+++ b/src/main/java/com/btkelly/gnag/tasks/CheckLocalTask.java
@@ -55,7 +55,7 @@ public class CheckLocalTask extends BaseCheckTask {
 
         ViolationComment violationComment = buildViolationComment();
 
-        File gnagReportDirectory = new File(getProject().getProjectDir(), "/build/outputs/gnag/");
+        File gnagReportDirectory = new File(getProject().getProjectDir(), "/build/reports/gnag/");
         File gnagReportFile = new File(gnagReportDirectory, REPORT_FILE_NAME);
 
         try {


### PR DESCRIPTION
test reports are generated under the reports directory, so figured this would make sense for all reports
