### PR TITLE
Format Android lint violation code correctly in local report

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile 'com.squareup.okhttp3:logging-interceptor:3.2.0'
     compile 'com.github.stkent:githubdiffparser:1.0.1'
     compile 'org.jetbrains:annotations:15.0'
+    compile 'org.pegdown:pegdown:1.6.0'
 
     // Built in checks
     compile 'com.puppycrawl.tools:checkstyle:6.19'

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -70,8 +70,6 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                 final String notNullMessageInHtml =
                         sanitizeToNonNull(markdownProcessor.markdownToHtml(messageInMarkdown))
                         .replaceAll("</?p>", "")
-
-            println markdownProcessor.markdownToHtml("https://developer.android.com/preview/backup/index.html")
             
                 final String nullableMessageInHtml = notNullMessageInHtml.isEmpty() ? null : notNullMessageInHtml
             

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -31,7 +31,7 @@ import static org.pegdown.Extensions.*
  */
 class AndroidLintViolationDetector extends BaseViolationDetector {
     
-    private static final int GFM_PEGDOWN_PROCESSOR_EXTENSIONS = HARDWRAPS & AUTOLINKS & FENCED_CODE_BLOCKS
+    private static final int GFM_PEGDOWN_PROCESSOR_EXTENSIONS = HARDWRAPS | AUTOLINKS | FENCED_CODE_BLOCKS
 
     private final AndroidLintExtension androidLintExtension;
 
@@ -70,6 +70,8 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                 final String notNullMessageInHtml =
                         sanitizeToNonNull(markdownProcessor.markdownToHtml(messageInMarkdown))
                         .replaceAll("</?p>", "")
+
+            println markdownProcessor.markdownToHtml("https://developer.android.com/preview/backup/index.html")
             
                 final String nullableMessageInHtml = notNullMessageInHtml.isEmpty() ? null : notNullMessageInHtml
             

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -19,16 +19,19 @@ import com.btkelly.gnag.extensions.AndroidLintExtension
 import com.btkelly.gnag.models.Violation
 import groovy.util.slurpersupport.GPathResult
 import org.gradle.api.Project
+import org.pegdown.PegDownProcessor
 
 import static com.btkelly.gnag.extensions.AndroidLintExtension.SEVERITY_ERROR
 import static com.btkelly.gnag.extensions.AndroidLintExtension.SEVERITY_WARNING
-import static com.btkelly.gnag.utils.StringUtils.sanitizeToNonNull
 import static com.btkelly.gnag.utils.StringUtils.sanitizePreservingNulls
-
+import static com.btkelly.gnag.utils.StringUtils.sanitizeToNonNull
+import static org.pegdown.Extensions.*
 /**
  * Created by bobbake4 on 4/18/16.
  */
 class AndroidLintViolationDetector extends BaseViolationDetector {
+    
+    private static final int GFM_PEGDOWN_PROCESSOR_EXTENSIONS = HARDWRAPS & AUTOLINKS & FENCED_CODE_BLOCKS
 
     private final AndroidLintExtension androidLintExtension;
 
@@ -62,13 +65,21 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
             .each { violation ->
                 final String violationName = sanitizeToNonNull((String) violation.@id.text())
             
+                final String messageInMarkdown = sanitizeToNonNull((String) violation.@message.text())
+                final PegDownProcessor markdownProcessor = new PegDownProcessor(GFM_PEGDOWN_PROCESSOR_EXTENSIONS)
+                final String notNullMessageInHtml =
+                        sanitizeToNonNull(markdownProcessor.markdownToHtml(messageInMarkdown))
+                        .replaceAll("</?p>", "")
+            
+                final String nullableMessageInHtml = notNullMessageInHtml.isEmpty() ? null : notNullMessageInHtml
+            
                 final String lineNumberString = sanitizeToNonNull((String) violation.location.@line.text())
                 final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationName)
             
                 result.add(new Violation(
                         violationName,
                         name(),
-                        sanitizePreservingNulls((String) violation.@message.text()),
+                        nullableMessageInHtml,
                         sanitizePreservingNulls((String) violation.@url.text()),
                         computeFilePathRelativeToProjectRoot((String) violation.location.@file.text()),
                         lineNumber))


### PR DESCRIPTION
Closes #74 #75.

**Before (see `AllowBackup` violation):**

<img width="1440" alt="screen shot 2016-07-03 at 8 15 59 pm" src="https://cloud.githubusercontent.com/assets/6463980/16548679/773d801c-4162-11e6-90ad-2e6af9805a96.png">

**After (see `AllowBackup` violation):**

<img width="1440" alt="screen shot 2016-07-03 at 9 19 49 pm" src="https://cloud.githubusercontent.com/assets/6463980/16548746/eee14170-4163-11e6-8ff4-84785333f2a8.png">

---

I haven't tested this with the report task yet - need to check that HTML encoding is correct, etc.
