### PR TITLE
Handle multiple URLs gracefully

### DIFF
--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -62,29 +62,35 @@ public final class Violation {
     private final Integer fileLineNumber;
 
     @Nullable
-    private final String primaryUrl;
+    private final String typeUrl;
     
     @NotNull
     private final List<String> secondaryUrls;
 
+    /**
+     * @param typeUrl a URL identifying a resource that provides more information on this violation's type
+     */
     public Violation(
             @NotNull final String type,
             @NotNull final String reporterName,
             @Nullable final String comment,
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber,
-            @Nullable final String primaryUrl) {
+            @Nullable final String typeUrl) {
 
         this(type, reporterName, comment, relativeFilePath, fileLineNumber, typeUrl, new ArrayList<>());
     }
 
+    /**
+     * @param typeUrl a URL identifying a resource that provides more information on this violation's type
+     */
     public Violation(
             @NotNull final String type,
             @NotNull final String reporterName,
             @Nullable final String comment,
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber,
-            @Nullable final String primaryUrl,
+            @Nullable final String typeUrl,
             @NotNull final List<String> secondaryUrls) {
 
         this.type = type;
@@ -99,7 +105,7 @@ public final class Violation {
             this.fileLineNumber = fileLineNumber;
         }
 
-        this.primaryUrl = primaryUrl;
+        this.typeUrl = typeUrl;
         this.secondaryUrls = secondaryUrls;
     }
 
@@ -129,8 +135,8 @@ public final class Violation {
     }
 
     @Nullable
-    public String getPrimaryUrl() {
-        return primaryUrl;
+    public String getTypeUrl() {
+        return typeUrl;
     }
 
     @NotNull
@@ -159,7 +165,7 @@ public final class Violation {
             return false;
         if (fileLineNumber != null ? !fileLineNumber.equals(violation.fileLineNumber) : violation.fileLineNumber != null)
             return false;
-        if (primaryUrl != null ? !primaryUrl.equals(violation.primaryUrl) : violation.primaryUrl != null) return false;
+        if (typeUrl != null ? !typeUrl.equals(violation.typeUrl) : violation.typeUrl != null) return false;
         return secondaryUrls.equals(violation.secondaryUrls);
 
     }
@@ -171,7 +177,7 @@ public final class Violation {
         result = 31 * result + (comment != null ? comment.hashCode() : 0);
         result = 31 * result + (relativeFilePath != null ? relativeFilePath.hashCode() : 0);
         result = 31 * result + (fileLineNumber != null ? fileLineNumber.hashCode() : 0);
-        result = 31 * result + (primaryUrl != null ? primaryUrl.hashCode() : 0);
+        result = 31 * result + (typeUrl != null ? typeUrl.hashCode() : 0);
         result = 31 * result + secondaryUrls.hashCode();
         return result;
     }

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -18,6 +18,7 @@ package com.btkelly.gnag.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -74,7 +75,7 @@ public final class Violation {
             @Nullable final Integer fileLineNumber,
             @Nullable final String primaryUrl) {
 
-        this(type, reporterName, comment, relativeFilePath, fileLineNumber, primaryUrl, new String[]{});
+        this(type, reporterName, comment, relativeFilePath, fileLineNumber, typeUrl, new ArrayList<>());
     }
 
     public Violation(

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -67,6 +67,16 @@ public final class Violation {
     @NotNull
     private final List<String> secondaryUrls;
 
+    public Violation(
+            @NotNull final String type,
+            @NotNull final String reporterName,
+            @Nullable final String comment,
+            @Nullable final String relativeFilePath,
+            @Nullable final Integer fileLineNumber) {
+
+        this(type, reporterName, comment, relativeFilePath, fileLineNumber, null);
+    }
+
     /**
      * @param typeUrl a URL identifying a resource that provides more information on this violation's type
      */

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -78,7 +78,8 @@ public final class Violation {
     }
 
     /**
-     * @param typeUrl a URL identifying a resource that provides more information on this violation's type
+     * @param typeUrl a URL identifying a resource that provides more information on this violation's type; null if no
+     *                such resource is known
      */
     public Violation(
             @NotNull final String type,
@@ -92,7 +93,8 @@ public final class Violation {
     }
 
     /**
-     * @param typeUrl a URL identifying a resource that provides more information on this violation's type
+     * @param typeUrl a URL identifying a resource that provides more information on this violation's type; null if no
+     *                such resource is known
      */
     public Violation(
             @NotNull final String type,

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
 public final class Violation {
 
@@ -64,7 +65,7 @@ public final class Violation {
     private final String primaryUrl;
     
     @NotNull
-    private final String[] secondaryUrls;
+    private final List<String> secondaryUrls;
 
     public Violation(
             @NotNull final String name,
@@ -84,7 +85,7 @@ public final class Violation {
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber,
             @Nullable final String primaryUrl,
-            @NotNull final String[] secondaryUrls) {
+            @NotNull final List<String> secondaryUrls) {
 
         this.name = name;
         this.reporterName = reporterName;
@@ -133,7 +134,7 @@ public final class Violation {
     }
 
     @NotNull
-    public String[] getSecondaryUrls() {
+    public List<String> getSecondaryUrls() {
         return secondaryUrls;
     }
 
@@ -142,6 +143,7 @@ public final class Violation {
     }
 
     // Generated equals and hashcode
+
 
     @Override
     public boolean equals(final Object o) {
@@ -158,8 +160,7 @@ public final class Violation {
         if (fileLineNumber != null ? !fileLineNumber.equals(violation.fileLineNumber) : violation.fileLineNumber != null)
             return false;
         if (primaryUrl != null ? !primaryUrl.equals(violation.primaryUrl) : violation.primaryUrl != null) return false;
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
-        return Arrays.equals(secondaryUrls, violation.secondaryUrls);
+        return secondaryUrls.equals(violation.secondaryUrls);
 
     }
 
@@ -171,7 +172,7 @@ public final class Violation {
         result = 31 * result + (relativeFilePath != null ? relativeFilePath.hashCode() : 0);
         result = 31 * result + (fileLineNumber != null ? fileLineNumber.hashCode() : 0);
         result = 31 * result + (primaryUrl != null ? primaryUrl.hashCode() : 0);
-        result = 31 * result + Arrays.hashCode(secondaryUrls);
+        result = 31 * result + secondaryUrls.hashCode();
         return result;
     }
     

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -63,12 +63,12 @@ public final class Violation {
     private final Integer fileLineNumber;
 
     public Violation(
-            @NotNull  final String name,
-            @NotNull  final String reporterName,
+            @NotNull final String name,
+            @NotNull final String reporterName,
             @Nullable final String comment,
-            @Nullable final String primaryUrl,
             @Nullable final String relativeFilePath,
-            @Nullable final Integer fileLineNumber) {
+            @Nullable final Integer fileLineNumber,
+            @Nullable final String primaryUrl) {
 
         this.name = name;
         this.reporterName = reporterName;

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -18,9 +18,7 @@ package com.btkelly.gnag.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 
 public final class Violation {
 
@@ -65,7 +63,7 @@ public final class Violation {
     private final String typeUrl;
     
     @NotNull
-    private final List<String> secondaryUrls;
+    private final String[] secondaryUrls;
 
     public Violation(
             @NotNull final String type,
@@ -89,7 +87,7 @@ public final class Violation {
             @Nullable final Integer fileLineNumber,
             @Nullable final String typeUrl) {
 
-        this(type, reporterName, comment, relativeFilePath, fileLineNumber, typeUrl, new ArrayList<>());
+        this(type, reporterName, comment, relativeFilePath, fileLineNumber, typeUrl, new String[]{});
     }
 
     /**
@@ -103,7 +101,7 @@ public final class Violation {
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber,
             @Nullable final String typeUrl,
-            @NotNull final List<String> secondaryUrls) {
+            @NotNull final String[] secondaryUrls) {
 
         this.type = type;
         this.reporterName = reporterName;
@@ -152,7 +150,7 @@ public final class Violation {
     }
 
     @NotNull
-    public List<String> getSecondaryUrls() {
+    public String[] getSecondaryUrls() {
         return secondaryUrls;
     }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -54,7 +54,7 @@ public final class Violation {
     private final String comment;
 
     @Nullable
-    private final String url;
+    private final String primaryUrl;
 
     @Nullable
     private final String relativeFilePath;
@@ -66,14 +66,14 @@ public final class Violation {
             @NotNull  final String name,
             @NotNull  final String reporterName,
             @Nullable final String comment,
-            @Nullable final String url,
+            @Nullable final String primaryUrl,
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber) {
 
         this.name = name;
         this.reporterName = reporterName;
         this.comment = comment;
-        this.url = url;
+        this.primaryUrl = primaryUrl;
         this.relativeFilePath = relativeFilePath;
 
         // Treat a line number of 0 as equivalent to a missing line number.
@@ -100,8 +100,8 @@ public final class Violation {
     }
 
     @Nullable
-    public String getUrl() {
-        return url;
+    public String getPrimaryUrl() {
+        return primaryUrl;
     }
 
     @Nullable
@@ -130,7 +130,7 @@ public final class Violation {
         if (!name.equals(violation.name)) return false;
         if (!reporterName.equals(violation.reporterName)) return false;
         if (comment != null ? !comment.equals(violation.comment) : violation.comment != null) return false;
-        if (url != null ? !url.equals(violation.url) : violation.url != null) return false;
+        if (primaryUrl != null ? !primaryUrl.equals(violation.primaryUrl) : violation.primaryUrl != null) return false;
         if (relativeFilePath != null ? !relativeFilePath.equals(violation.relativeFilePath) : violation.relativeFilePath != null)
             return false;
         return fileLineNumber != null ? fileLineNumber.equals(violation.fileLineNumber) : violation.fileLineNumber == null;
@@ -142,7 +142,7 @@ public final class Violation {
         int result = name.hashCode();
         result = 31 * result + reporterName.hashCode();
         result = 31 * result + (comment != null ? comment.hashCode() : 0);
-        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (primaryUrl != null ? primaryUrl.hashCode() : 0);
         result = 31 * result + (relativeFilePath != null ? relativeFilePath.hashCode() : 0);
         result = 31 * result + (fileLineNumber != null ? fileLineNumber.hashCode() : 0);
         return result;

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -18,7 +18,6 @@ package com.btkelly.gnag.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
@@ -47,7 +46,7 @@ public final class Violation {
     };
 
     @NotNull
-    private final String name;
+    private final String type;
 
     @NotNull
     private final String reporterName;
@@ -68,18 +67,18 @@ public final class Violation {
     private final List<String> secondaryUrls;
 
     public Violation(
-            @NotNull final String name,
+            @NotNull final String type,
             @NotNull final String reporterName,
             @Nullable final String comment,
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber,
             @Nullable final String primaryUrl) {
 
-        this(name, reporterName, comment, relativeFilePath, fileLineNumber, primaryUrl, new String[]{});
+        this(type, reporterName, comment, relativeFilePath, fileLineNumber, primaryUrl, new String[]{});
     }
 
     public Violation(
-            @NotNull final String name,
+            @NotNull final String type,
             @NotNull final String reporterName,
             @Nullable final String comment,
             @Nullable final String relativeFilePath,
@@ -87,7 +86,7 @@ public final class Violation {
             @Nullable final String primaryUrl,
             @NotNull final List<String> secondaryUrls) {
 
-        this.name = name;
+        this.type = type;
         this.reporterName = reporterName;
         this.comment = comment;
         this.relativeFilePath = relativeFilePath;
@@ -104,8 +103,8 @@ public final class Violation {
     }
 
     @NotNull
-    public String getName() {
-        return name;
+    public String getType() {
+        return type;
     }
 
     @NotNull
@@ -152,7 +151,7 @@ public final class Violation {
 
         final Violation violation = (Violation) o;
 
-        if (!name.equals(violation.name)) return false;
+        if (!type.equals(violation.type)) return false;
         if (!reporterName.equals(violation.reporterName)) return false;
         if (comment != null ? !comment.equals(violation.comment) : violation.comment != null) return false;
         if (relativeFilePath != null ? !relativeFilePath.equals(violation.relativeFilePath) : violation.relativeFilePath != null)
@@ -166,7 +165,7 @@ public final class Violation {
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
+        int result = type.hashCode();
         result = 31 * result + reporterName.hashCode();
         result = 31 * result + (comment != null ? comment.hashCode() : 0);
         result = 31 * result + (relativeFilePath != null ? relativeFilePath.hashCode() : 0);

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -18,6 +18,7 @@ package com.btkelly.gnag.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.Comparator;
 
 public final class Violation {
@@ -54,13 +55,16 @@ public final class Violation {
     private final String comment;
 
     @Nullable
-    private final String primaryUrl;
-
-    @Nullable
     private final String relativeFilePath;
 
     @Nullable
     private final Integer fileLineNumber;
+
+    @Nullable
+    private final String primaryUrl;
+    
+    @NotNull
+    private final String[] secondaryUrls;
 
     public Violation(
             @NotNull final String name,
@@ -70,10 +74,21 @@ public final class Violation {
             @Nullable final Integer fileLineNumber,
             @Nullable final String primaryUrl) {
 
+        this(name, reporterName, comment, relativeFilePath, fileLineNumber, primaryUrl, new String[]{});
+    }
+
+    public Violation(
+            @NotNull final String name,
+            @NotNull final String reporterName,
+            @Nullable final String comment,
+            @Nullable final String relativeFilePath,
+            @Nullable final Integer fileLineNumber,
+            @Nullable final String primaryUrl,
+            @NotNull final String[] secondaryUrls) {
+
         this.name = name;
         this.reporterName = reporterName;
         this.comment = comment;
-        this.primaryUrl = primaryUrl;
         this.relativeFilePath = relativeFilePath;
 
         // Treat a line number of 0 as equivalent to a missing line number.
@@ -82,6 +97,9 @@ public final class Violation {
         } else {
             this.fileLineNumber = fileLineNumber;
         }
+
+        this.primaryUrl = primaryUrl;
+        this.secondaryUrls = secondaryUrls;
     }
 
     @NotNull
@@ -100,11 +118,6 @@ public final class Violation {
     }
 
     @Nullable
-    public String getPrimaryUrl() {
-        return primaryUrl;
-    }
-
-    @Nullable
     public String getRelativeFilePath() {
         return relativeFilePath;
     }
@@ -112,6 +125,16 @@ public final class Violation {
     @Nullable
     public Integer getFileLineNumber() {
         return fileLineNumber;
+    }
+
+    @Nullable
+    public String getPrimaryUrl() {
+        return primaryUrl;
+    }
+
+    @NotNull
+    public String[] getSecondaryUrls() {
+        return secondaryUrls;
     }
 
     public boolean hasAllLocationInfo() {
@@ -130,10 +153,13 @@ public final class Violation {
         if (!name.equals(violation.name)) return false;
         if (!reporterName.equals(violation.reporterName)) return false;
         if (comment != null ? !comment.equals(violation.comment) : violation.comment != null) return false;
-        if (primaryUrl != null ? !primaryUrl.equals(violation.primaryUrl) : violation.primaryUrl != null) return false;
         if (relativeFilePath != null ? !relativeFilePath.equals(violation.relativeFilePath) : violation.relativeFilePath != null)
             return false;
-        return fileLineNumber != null ? fileLineNumber.equals(violation.fileLineNumber) : violation.fileLineNumber == null;
+        if (fileLineNumber != null ? !fileLineNumber.equals(violation.fileLineNumber) : violation.fileLineNumber != null)
+            return false;
+        if (primaryUrl != null ? !primaryUrl.equals(violation.primaryUrl) : violation.primaryUrl != null) return false;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        return Arrays.equals(secondaryUrls, violation.secondaryUrls);
 
     }
 
@@ -142,10 +168,11 @@ public final class Violation {
         int result = name.hashCode();
         result = 31 * result + reporterName.hashCode();
         result = 31 * result + (comment != null ? comment.hashCode() : 0);
-        result = 31 * result + (primaryUrl != null ? primaryUrl.hashCode() : 0);
         result = 31 * result + (relativeFilePath != null ? relativeFilePath.hashCode() : 0);
         result = 31 * result + (fileLineNumber != null ? fileLineNumber.hashCode() : 0);
+        result = 31 * result + (primaryUrl != null ? primaryUrl.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(secondaryUrls);
         return result;
     }
-
+    
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -18,7 +18,9 @@ package com.btkelly.gnag.models;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 public final class Violation {
 
@@ -63,7 +65,7 @@ public final class Violation {
     private final String typeUrl;
     
     @NotNull
-    private final String[] secondaryUrls;
+    private final List<String> secondaryUrls;
 
     public Violation(
             @NotNull final String type,
@@ -87,7 +89,7 @@ public final class Violation {
             @Nullable final Integer fileLineNumber,
             @Nullable final String typeUrl) {
 
-        this(type, reporterName, comment, relativeFilePath, fileLineNumber, typeUrl, new String[]{});
+        this(type, reporterName, comment, relativeFilePath, fileLineNumber, typeUrl, new ArrayList<>());
     }
 
     /**
@@ -101,7 +103,7 @@ public final class Violation {
             @Nullable final String relativeFilePath,
             @Nullable final Integer fileLineNumber,
             @Nullable final String typeUrl,
-            @NotNull final String[] secondaryUrls) {
+            @NotNull final List<String> secondaryUrls) {
 
         this.type = type;
         this.reporterName = reporterName;
@@ -150,7 +152,7 @@ public final class Violation {
     }
 
     @NotNull
-    public String[] getSecondaryUrls() {
+    public List<String> getSecondaryUrls() {
         return secondaryUrls;
     }
 
@@ -159,8 +161,7 @@ public final class Violation {
     }
 
     // Generated equals and hashcode
-
-
+    
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -177,7 +178,6 @@ public final class Violation {
             return false;
         if (typeUrl != null ? !typeUrl.equals(violation.typeUrl) : violation.typeUrl != null) return false;
         return secondaryUrls.equals(violation.secondaryUrls);
-
     }
 
     @Override

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -74,8 +74,9 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                 final String lineNumberString = sanitizeToNonNull((String) violation.location.@line.text())
                 final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationType)
             
-                final String[] secondaryUrls =
-                        computeSecondaryUrls(sanitizePreservingNulls((String) violation.@urls.text()))
+                final String[] secondaryUrls = computeSecondaryUrls(
+                        sanitizePreservingNulls((String) violation.@urls.text()),
+                        nullableMessageInHtml)
             
                 result.add(new Violation(
                         violationType,
@@ -108,9 +109,30 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
         }
     }
     
-    private static String[] computeSecondaryUrls(final String secondaryUrlsString) {
+    static List<String> computeSecondaryUrls(
+            final String secondaryUrlsString,
+            final String nullableMessageInHtml) {
+        
+        if (secondaryUrlsString == null) {
+            return new ArrayList<>()
+        }
+        
         // Uses positive lookaround to avoiding splitting at comma characters _within_ URLs.
-        return secondaryUrlsString.split(",(?=https?)")
+        final String[] parsedUrls = Arrays.asList(secondaryUrlsString.split(",(?=https?)"))
+        
+        if (nullableMessageInHtml == null) {
+            return parsedUrls
+        }
+
+        final List<String> result = new ArrayList<>()
+        
+        for (final String parsedUrl: parsedUrls) {
+            if (!nullableMessageInHtml.contains(parsedUrl)) {
+                result.add(parsedUrl)
+            }
+        }
+        
+        return result
     }
     
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -63,7 +63,7 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
 
         xml.issue.findAll { severityEnabled((String) it.@severity.text()) }
             .each { violation ->
-                final String violationName = sanitizeToNonNull((String) violation.@id.text())
+                final String violationType = sanitizeToNonNull((String) violation.@id.text())
             
                 final String messageInMarkdown = sanitizeToNonNull((String) violation.@message.text())
                 final PegDownProcessor markdownProcessor = new PegDownProcessor(GFM_PEGDOWN_PROCESSOR_EXTENSIONS)
@@ -74,10 +74,10 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                 final String nullableMessageInHtml = notNullMessageInHtml.isEmpty() ? null : notNullMessageInHtml
             
                 final String lineNumberString = sanitizeToNonNull((String) violation.location.@line.text())
-                final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationName)
+                final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationType)
             
                 result.add(new Violation(
-                        violationName,
+                        violationType,
                         name(),
                         nullableMessageInHtml,
                         computeFilePathRelativeToProjectRoot((String) violation.location.@file.text()),

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -80,9 +80,9 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                         violationName,
                         name(),
                         nullableMessageInHtml,
-                        sanitizePreservingNulls((String) violation.@url.text()),
                         computeFilePathRelativeToProjectRoot((String) violation.location.@file.text()),
-                        lineNumber))
+                        lineNumber,
+                        sanitizePreservingNulls((String) violation.@url.text())))
             }
 
         return result

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -26,9 +26,7 @@ import static com.btkelly.gnag.extensions.AndroidLintExtension.SEVERITY_WARNING
 import static com.btkelly.gnag.utils.StringUtils.sanitizePreservingNulls
 import static com.btkelly.gnag.utils.StringUtils.sanitizeToNonNull
 import static org.pegdown.Extensions.*
-/**
- * Created by bobbake4 on 4/18/16.
- */
+
 class AndroidLintViolationDetector extends BaseViolationDetector {
     
     private static final int GFM_PEGDOWN_PROCESSOR_EXTENSIONS = HARDWRAPS | AUTOLINKS | FENCED_CODE_BLOCKS

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -76,13 +76,17 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                 final String lineNumberString = sanitizeToNonNull((String) violation.location.@line.text())
                 final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationType)
             
+                final String[] secondaryUrls =
+                        computeSecondaryUrls(sanitizePreservingNulls((String) violation.@urls.text()))
+            
                 result.add(new Violation(
                         violationType,
                         name(),
                         nullableMessageInHtml,
                         computeFilePathRelativeToProjectRoot((String) violation.location.@file.text()),
                         lineNumber,
-                        sanitizePreservingNulls((String) violation.@url.text())))
+                        null,
+                        secondaryUrls));
             }
 
         return result
@@ -105,4 +109,10 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
             return severity.equals(SEVERITY_ERROR)
         }
     }
+    
+    private static String[] computeSecondaryUrls(final String secondaryUrlsString) {
+        // Uses positive lookaround to avoiding splitting at comma characters _within_ URLs.
+        return secondaryUrlsString.split(",(?=https?)")
+    }
+    
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/BaseViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/BaseViolationDetector.groovy
@@ -52,10 +52,10 @@ abstract class BaseViolationDetector implements ViolationDetector {
 
     /**
      * @param lineNumberString a String we would like to parse into an integer value.
-     * @param violationName the name of the violation currently being parsed. Used for logging only.
+     * @param violationType the name of the violation currently being parsed. Used for logging only.
      * @return a positive integer, if lineNumberString can be parsed into such a value; null in any other case.
      */
-    protected Integer computeLineNumberFromString(final String lineNumberString, final String violationName) {
+    protected Integer computeLineNumberFromString(final String lineNumberString, final String violationType) {
         if (lineNumberString.isEmpty()) {
             return null
         } else {
@@ -67,14 +67,14 @@ abstract class BaseViolationDetector implements ViolationDetector {
                 } else {
                     System.out.println(
                             "Invalid line number: + " + result +
-                            " for " + name() + " violation: " + violationName)
+                            " for " + name() + " violation: " + violationType)
                     
                     return null
                 }
             } catch (final NumberFormatException ignored) {
                 System.out.println(
                         "Error parsing line number string: \"" + lineNumberString +
-                        "\" for " + name() + " violation: " + violationName)
+                        "\" for " + name() + " violation: " + violationType)
 
                 return null
             }

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/CheckstyleViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/CheckstyleViolationDetector.groovy
@@ -72,9 +72,9 @@ class CheckstyleViolationDetector extends BaseExecutedViolationDetector {
                         shortViolationName,
                         name(),
                         sanitizePreservingNulls((String) violation.@message.text()),
-                        null,
                         computeFilePathRelativeToProjectRoot((String) file.@name.text()),
-                        lineNumber))
+                        lineNumber,
+                        null))
             }
         }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/CheckstyleViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/CheckstyleViolationDetector.groovy
@@ -73,8 +73,7 @@ class CheckstyleViolationDetector extends BaseExecutedViolationDetector {
                         name(),
                         sanitizePreservingNulls((String) violation.@message.text()),
                         computeFilePathRelativeToProjectRoot((String) file.@name.text()),
-                        lineNumber,
-                        null))
+                        lineNumber))
             }
         }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
@@ -105,8 +105,7 @@ class FindbugsViolationDetector extends BaseExecutedViolationDetector {
                         name(),
                         sanitizePreservingNulls((String) violation.ShortMessage.text()),
                         relativeFilePath,
-                        lineNumber,
-                        null))
+                        lineNumber))
             }
 
         return result

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
@@ -92,16 +92,16 @@ class FindbugsViolationDetector extends BaseExecutedViolationDetector {
 
         xml.BugInstance.list()
             .each { violation ->
-                final String violationName = sanitizeToNonNull((String) violation.@type.text())
+                final String violationType = sanitizeToNonNull((String) violation.@type.text())
 
                 final String relativeFilePath =
                         computeRelativeFilePathIfPossible((GPathResult) violation, sourceFilePaths)
             
                 final String lineNumberString = sanitizeToNonNull((String) violation.SourceLine.@end.text())
-                final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationName)
+                final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationType)
 
                 result.add(new Violation(
-                        violationName,
+                        violationType,
                         name(),
                         sanitizePreservingNulls((String) violation.ShortMessage.text()),
                         relativeFilePath,

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
@@ -104,9 +104,9 @@ class FindbugsViolationDetector extends BaseExecutedViolationDetector {
                         violationName,
                         name(),
                         sanitizePreservingNulls((String) violation.ShortMessage.text()),
-                        null,
                         relativeFilePath,
-                        lineNumber))
+                        lineNumber,
+                        null))
             }
 
         return result

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
@@ -73,9 +73,9 @@ class PMDViolationDetector extends BaseExecutedViolationDetector {
                         violationName,
                         name(),
                         sanitizePreservingNulls((String) violation.text()),
-                        sanitizePreservingNulls((String) violation.@externalInfoUrl.text()),
                         computeFilePathRelativeToProjectRoot((String) file.@name.text()),
-                        lineNumber))
+                        lineNumber,
+                        sanitizePreservingNulls((String) violation.@externalInfoUrl.text())))
             }
         }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
@@ -64,13 +64,13 @@ class PMDViolationDetector extends BaseExecutedViolationDetector {
 
         xml.file.each { file ->
             file.violation.each { violation ->
-                final String violationName = sanitizeToNonNull((String) violation.@rule.text())
+                final String violationType = sanitizeToNonNull((String) violation.@rule.text())
 
                 final String lineNumberString = sanitizeToNonNull((String) violation.@endline.text())
-                final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationName)
+                final Integer lineNumber = computeLineNumberFromString(lineNumberString, violationType)
                 
                 result.add(new Violation(
-                        violationName,
+                        violationType,
                         name(),
                         sanitizePreservingNulls((String) violation.text()),
                         computeFilePathRelativeToProjectRoot((String) file.@name.text()),

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -19,8 +19,6 @@ import com.btkelly.gnag.models.Violation;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 /**
  * Creates formatted HTML strings representing individual violations.
  */
@@ -145,20 +143,21 @@ public final class ViolationFormatter {
             @NotNull final Violation violation,
             @NotNull final HtmlStringBuilder builder) {
 
-        final List<String> secondaryViolationUrls = violation.getSecondaryUrls();
+        final String[] secondaryViolationUrls = violation.getSecondaryUrls();
+        final int numberOfSecondaryViolationUrls = secondaryViolationUrls.length;
 
-        if (!secondaryViolationUrls.isEmpty()) {
+        if (numberOfSecondaryViolationUrls > 0) {
             builder
                     .insertLineBreak()
                     .appendBold("Related Links: ");
             
-            for (int urlNumber = 0; urlNumber < secondaryViolationUrls.size(); urlNumber++) {
+            for (int urlNumber = 0; urlNumber < numberOfSecondaryViolationUrls; urlNumber++) {
                 builder
                         .append("[")
-                        .appendLink(Integer.toString(urlNumber), secondaryViolationUrls.get(urlNumber))
+                        .appendLink(Integer.toString(urlNumber), secondaryViolationUrls[urlNumber])
                         .append("]");
                 
-                if (urlNumber != secondaryViolationUrls.size() - 1) {
+                if (urlNumber != numberOfSecondaryViolationUrls - 1) {
                     builder.append(", ");
                 }
             }

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -80,13 +80,13 @@ public final class ViolationFormatter {
 
         builder.appendBold("Violation: ");
 
-        final String violationName = violation.getName();
+        final String violationType = violation.getType();
         final String primaryViolationUrl = violation.getPrimaryUrl();
 
         if (StringUtils.isNotBlank(primaryViolationUrl)) {
-            builder.appendLink(violationName, primaryViolationUrl);
+            builder.appendLink(violationType, primaryViolationUrl);
         } else {
-            builder.append(violationName);
+            builder.append(violationType);
         }
     }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -81,10 +81,10 @@ public final class ViolationFormatter {
         builder.appendBold("Violation: ");
 
         final String violationType = violation.getType();
-        final String primaryViolationUrl = violation.getPrimaryUrl();
+        final String violationTypeUrl = violation.getTypeUrl();
 
-        if (StringUtils.isNotBlank(primaryViolationUrl)) {
-            builder.appendLink(violationType, primaryViolationUrl);
+        if (StringUtils.isNotBlank(violationTypeUrl)) {
+            builder.appendLink(violationType, violationTypeUrl);
         } else {
             builder.append(violationType);
         }

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -144,7 +144,7 @@ public final class ViolationFormatter {
     }
 
     private ViolationFormatter() {
-
+        // This constructor intentionally left blank.
     }
 
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -19,6 +19,8 @@ import com.btkelly.gnag.models.Violation;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * Creates formatted HTML strings representing individual violations.
  */
@@ -143,8 +145,8 @@ public final class ViolationFormatter {
             @NotNull final Violation violation,
             @NotNull final HtmlStringBuilder builder) {
 
-        final String[] secondaryViolationUrls = violation.getSecondaryUrls();
-        final int numberOfSecondaryViolationUrls = secondaryViolationUrls.length;
+        final List<String> secondaryViolationUrls = violation.getSecondaryUrls();
+        final int numberOfSecondaryViolationUrls = secondaryViolationUrls.size();
 
         if (numberOfSecondaryViolationUrls > 0) {
             builder
@@ -154,7 +156,7 @@ public final class ViolationFormatter {
             for (int urlNumber = 0; urlNumber < numberOfSecondaryViolationUrls; urlNumber++) {
                 builder
                         .append("[")
-                        .appendLink(Integer.toString(urlNumber), secondaryViolationUrls[urlNumber])
+                        .appendLink(Integer.toString(urlNumber), secondaryViolationUrls.get(urlNumber))
                         .append("]");
                 
                 if (urlNumber != numberOfSecondaryViolationUrls - 1) {

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -83,10 +83,10 @@ public final class ViolationFormatter {
         builder.appendBold(VIOLATION_NAME_LABEL);
 
         final String violationName = violation.getName();
-        final String violationUrl = violation.getUrl();
+        final String primaryViolationUrl = violation.getPrimaryUrl();
 
-        if (StringUtils.isNotBlank(violationUrl)) {
-            builder.appendLink(violationName, violationUrl);
+        if (StringUtils.isNotBlank(primaryViolationUrl)) {
+            builder.appendLink(violationName, primaryViolationUrl);
         } else {
             builder.append(violationName);
         }

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -151,13 +151,10 @@ public final class ViolationFormatter {
         if (numberOfSecondaryViolationUrls > 0) {
             builder
                     .insertLineBreak()
-                    .appendBold("Related Links: ");
+                    .appendBold("Related: ");
             
             for (int urlNumber = 0; urlNumber < numberOfSecondaryViolationUrls; urlNumber++) {
-                builder
-                        .append("[")
-                        .appendLink(Integer.toString(urlNumber), secondaryViolationUrls.get(urlNumber))
-                        .append("]");
+                builder.appendLink(secondaryViolationUrls.get(urlNumber), secondaryViolationUrls.get(urlNumber));
                 
                 if (urlNumber != numberOfSecondaryViolationUrls - 1) {
                     builder.append(", ");

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -19,16 +19,12 @@ import com.btkelly.gnag.models.Violation;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
  * Creates formatted HTML strings representing individual violations.
  */
 public final class ViolationFormatter {
-
-    private static final String VIOLATION_FILE_LABEL  = "File: ";
-    private static final String VIOLATION_LINE_LABEL  = "Line: ";
-    private static final String VIOLATION_NAME_LABEL  = "Violation: ";
-    private static final String VIOLATION_NOTES_LABEL = "Notes: ";
-    private static final String VIOLATION_REPORTER_LABEL = "Reporter: ";
 
     /**
      * Use this method to create a formatted HTML string representing a violation that will be posted as an inline
@@ -48,6 +44,7 @@ public final class ViolationFormatter {
         appendViolationReporterToBuilder(violation, builder);
         appendViolationNameToBuilder(violation, builder);
         appendViolationCommentToBuilderIfPresent(violation, builder);
+        appendSecondaryUrlsToBuilderIfPresent(violation, builder);
 
         return builder.toString();
     }
@@ -63,6 +60,7 @@ public final class ViolationFormatter {
         appendViolationNameToBuilder(violation, builder);
         appendLocationInformationToBuilderIfPresent(violation, builder);
         appendViolationCommentToBuilderIfPresent(violation, builder);
+        appendSecondaryUrlsToBuilderIfPresent(violation, builder);
 
         return builder.toString();
     }
@@ -71,7 +69,7 @@ public final class ViolationFormatter {
             @NotNull final Violation violation,
             @NotNull final HtmlStringBuilder builder) {
 
-        builder.appendBold(VIOLATION_REPORTER_LABEL);
+        builder.appendBold("Reporter: ");
         builder.append(violation.getReporterName());
         builder.insertLineBreak();
     }
@@ -80,7 +78,7 @@ public final class ViolationFormatter {
             @NotNull final Violation violation,
             @NotNull final HtmlStringBuilder builder) {
 
-        builder.appendBold(VIOLATION_NAME_LABEL);
+        builder.appendBold("Violation: ");
 
         final String violationName = violation.getName();
         final String primaryViolationUrl = violation.getPrimaryUrl();
@@ -115,7 +113,7 @@ public final class ViolationFormatter {
 
         builder
                 .insertLineBreak()
-                .appendBold(VIOLATION_FILE_LABEL)
+                .appendBold("File: ")
                 .append(violationRelativeFilePath);
     }
 
@@ -125,7 +123,7 @@ public final class ViolationFormatter {
 
         builder
                 .insertLineBreak()
-                .appendBold(VIOLATION_LINE_LABEL)
+                .appendBold("Line: ")
                 .append(Integer.toString(violationFileLineNumber));
     }
 
@@ -138,8 +136,32 @@ public final class ViolationFormatter {
         if (violationComment != null) {
             builder
                     .insertLineBreak()
-                    .appendBold(VIOLATION_NOTES_LABEL)
+                    .appendBold("Notes: ")
                     .append(violationComment);
+        }
+    }
+
+    private static void appendSecondaryUrlsToBuilderIfPresent(
+            @NotNull final Violation violation,
+            @NotNull final HtmlStringBuilder builder) {
+
+        final List<String> secondaryViolationUrls = violation.getSecondaryUrls();
+
+        if (!secondaryViolationUrls.isEmpty()) {
+            builder
+                    .insertLineBreak()
+                    .appendBold("Related Links: ");
+            
+            for (int urlNumber = 0; urlNumber < secondaryViolationUrls.size(); urlNumber++) {
+                builder
+                        .append("[")
+                        .appendLink(Integer.toString(urlNumber), secondaryViolationUrls.get(urlNumber))
+                        .append("]");
+                
+                if (urlNumber != secondaryViolationUrls.size() - 1) {
+                    builder.append(", ");
+                }
+            }
         }
     }
 

--- a/plugin/src/test/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetectorTest.groovy
+++ b/plugin/src/test/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetectorTest.groovy
@@ -1,0 +1,73 @@
+package com.btkelly.gnag.reporters
+
+class AndroidLintViolationDetectorTest extends GroovyTestCase {
+    
+    void test_missingUrlsNode() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                null,
+                "A newer version of com.android.support:appcompat-v7 than 23.3.0 is available: 24.0.0")
+        
+        assertEquals(new ArrayList<String>(), actualUrls)
+    }
+
+    void test_emptyUrlsNode() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                "",
+                "A newer version of com.android.support:appcompat-v7 than 23.3.0 is available: 24.0.0")
+        
+        assertEquals(new ArrayList<String>(), actualUrls)
+    }
+
+    void test_urlsNodeWithSingleEntry_notIncludedInMessage() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                "http://developer.android.com/reference/android/os/Build.VERSION_CODES.html",
+                "A newer version of com.android.support:appcompat-v7 than 23.3.0 is available: 24.0.0")
+        
+        def expectedUrls = new ArrayList<String>() {{
+            add("http://developer.android.com/reference/android/os/Build.VERSION_CODES.html")
+        }}
+        
+        assertEquals(expectedUrls, actualUrls)
+    }
+
+    void test_urlsNodeWithSingleEntry_includedInMessage() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                "https://developer.android.com/preview/backup/index.html",
+                "On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute `android:fullBackupContent` to specify an `@xml` resource which configures which files to backup. More info: https://developer.android.com/preview/backup/index.html")
+
+        assertEquals(new ArrayList<String>(), actualUrls)
+    }
+
+    void test_urlsNodeWithMultipleEntries_noneIncludedInMessage() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                "https://developer.android.com/preview/backup/index.html,http://developer.android.com/reference/android/R.attr.html#allowBackup",
+                "On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute `android:fullBackupContent` to specify an `@xml` resource which configures which files to backup.")
+
+        def expectedUrls = new ArrayList<String>() {{
+            add("https://developer.android.com/preview/backup/index.html")
+            add("http://developer.android.com/reference/android/R.attr.html#allowBackup")
+        }}
+
+        assertEquals(expectedUrls, actualUrls)
+    }
+
+    void test_urlsNodeWithMultipleEntries_someIncludedInMessage() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                "https://developer.android.com/preview/backup/index.html,http://developer.android.com/reference/android/R.attr.html#allowBackup",
+                "On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute `android:fullBackupContent` to specify an `@xml` resource which configures which files to backup. More info: https://developer.android.com/preview/backup/index.html")
+
+        def expectedUrls = new ArrayList<String>() {{
+            add("http://developer.android.com/reference/android/R.attr.html#allowBackup")
+        }}
+
+        assertEquals(expectedUrls, actualUrls)
+    }
+
+    void test_urlsNodeWithMultipleEntries_allIncludedInMessage() {
+        def actualUrls = AndroidLintViolationDetector.computeSecondaryUrls(
+                "https://developer.android.com/preview/backup/index.html,http://developer.android.com/reference/android/R.attr.html#allowBackup",
+                "On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute `android:fullBackupContent` to specify an `@xml` resource which configures which files to backup. More info: https://developer.android.com/preview/backup/index.html and http://developer.android.com/reference/android/R.attr.html#allowBackup")
+
+        assertEquals(new ArrayList<String>(), actualUrls)
+    }
+}

--- a/plugin/src/test/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetectorTest.groovy
+++ b/plugin/src/test/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetectorTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Bryan Kelly
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.btkelly.gnag.reporters
 
 class AndroidLintViolationDetectorTest extends GroovyTestCase {


### PR DESCRIPTION
Closes #113 

Example of new comment format (Android lint comments are the only comments whose format should have changed in this PR; that is the only checker that currently reports multiple URLs):

<img width="911" alt="screen shot 2016-07-10 at 10 14 38 pm" src="https://cloud.githubusercontent.com/assets/6463980/16718193/bbb4caa0-46eb-11e6-8f62-a46f28102fd8.png">

Added some unit tests for the plugin; not sure if CI job needs to be updated to run those.
