### PR TITLE
WIP [DO NOT MERGE] on #123, supporting build variants

### DIFF
--- a/buildAndRunExample.sh
+++ b/buildAndRunExample.sh
@@ -5,7 +5,7 @@
 if [ $? -eq 0 ]; then
 	cd example/
 
-	./gradlew clean gnagCheck
+	./gradlew clean gnagCheckDebug
 
 	cd ..
 fi

--- a/buildAndRunExample.sh
+++ b/buildAndRunExample.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-./gradlew clean publishGnagPublicationPublicationToMavenLocal
+./gradlew clean --stacktrace --debug publishGnagPublicationPublicationToMavenLocal
 
 if [ $? -eq 0 ]; then
 	cd example/
 
-	./gradlew clean gnagCheck
+	./gradlew clean gnagCheckDebug
 
 	cd ..
 fi

--- a/buildAndRunExample.sh
+++ b/buildAndRunExample.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-./gradlew clean --stacktrace --debug publishGnagPublicationPublicationToMavenLocal
+./gradlew clean publishGnagPublicationPublicationToMavenLocal
 
 if [ $? -eq 0 ]; then
 	cd example/
 
-	./gradlew clean gnagCheckDebug
+	./gradlew clean gnagCheck
 
 	cd ..
 fi

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     //Gradle specific classes for plugin creation
     compile gradleApi()
+    compile 'com.android.tools.build:gradle:2.2.1'
 
     compile 'com.squareup.retrofit2:retrofit:2.0.2'
     compile 'com.squareup.okhttp3:logging-interceptor:3.2.0'

--- a/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.java
@@ -27,39 +27,39 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+
 /**
  * Created by bobbake4 on 4/1/16.
  */
 public class GnagPlugin implements Plugin<Project> {
 
     @Override
-    public void apply(final Project project) {
+    public void apply(@NotNull final Project project) {
         GnagPluginExtension gnagPluginExtension = GnagPluginExtension.loadExtension(project);
 
         project.afterEvaluate(evaluatedProject -> {
             if (evaluatedProject.getPlugins().hasPlugin(AppPlugin.class)) {
                 AppExtension android = (AppExtension) evaluatedProject.getExtensions().getByName("android");
 
-                android.getApplicationVariants().forEach(
-                        variant -> configureTasks(evaluatedProject, gnagPluginExtension, variant));
+                addAllTasksToProject(project, gnagPluginExtension, android.getApplicationVariants());
             } else if (evaluatedProject.getPlugins().hasPlugin(LibraryPlugin.class)) {
                 LibraryExtension android = (LibraryExtension) evaluatedProject.getExtensions().getByName("android");
 
-                android.getLibraryVariants().forEach(
-                        variant -> configureTasks(evaluatedProject, gnagPluginExtension, variant));
+                addAllTasksToProject(project, gnagPluginExtension, android.getLibraryVariants());
             } else {
                 // fixme: throw a loud exception here
             }
         });
     }
-
-    private void configureTasks(
+    
+    private static void addAllTasksToProject(
             @NotNull final Project project,
             @NotNull final GnagPluginExtension gnagPluginExtension,
-            @NotNull final BaseVariant variant) {
-        
-        GnagCheckTask.addToProject(project, gnagPluginExtension, variant);
-        GnagReportTask.addToProject(project, gnagPluginExtension.github, variant);
+            @NotNull final Collection<? extends BaseVariant> variants) {
+
+        GnagCheckTask.addTasksToProject(project, gnagPluginExtension, variants);
+        GnagReportTask.addTasksToProject(project, gnagPluginExtension.github, variants);
     }
-    
+        
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.java
@@ -15,11 +15,17 @@
  */
 package com.btkelly.gnag;
 
+import com.android.build.gradle.AppExtension;
+import com.android.build.gradle.AppPlugin;
+import com.android.build.gradle.LibraryExtension;
+import com.android.build.gradle.LibraryPlugin;
+import com.android.build.gradle.api.BaseVariant;
 import com.btkelly.gnag.extensions.GnagPluginExtension;
-import com.btkelly.gnag.tasks.GnagCheck;
+import com.btkelly.gnag.tasks.GnagCheckTask;
 import com.btkelly.gnag.tasks.GnagReportTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Created by bobbake4 on 4/1/16.
@@ -27,13 +33,33 @@ import org.gradle.api.Project;
 public class GnagPlugin implements Plugin<Project> {
 
     @Override
-    public void apply(Project project) {
-
+    public void apply(final Project project) {
         GnagPluginExtension gnagPluginExtension = GnagPluginExtension.loadExtension(project);
 
-        project.afterEvaluate(target -> {
-            GnagCheck.addTask(target, gnagPluginExtension);
-            GnagReportTask.addTask(target, gnagPluginExtension.github);
+        project.afterEvaluate(evaluatedProject -> {
+            if (evaluatedProject.getPlugins().hasPlugin(AppPlugin.class)) {
+                AppExtension android = (AppExtension) evaluatedProject.getExtensions().getByName("android");
+
+                android.getApplicationVariants().forEach(
+                        variant -> configureTasks(evaluatedProject, gnagPluginExtension, variant));
+            } else if (evaluatedProject.getPlugins().hasPlugin(LibraryPlugin.class)) {
+                LibraryExtension android = (LibraryExtension) evaluatedProject.getExtensions().getByName("android");
+
+                android.getLibraryVariants().forEach(
+                        variant -> configureTasks(evaluatedProject, gnagPluginExtension, variant));
+            } else {
+                // fixme: throw a loud exception here
+            }
         });
     }
+
+    private void configureTasks(
+            @NotNull final Project project,
+            @NotNull final GnagPluginExtension gnagPluginExtension,
+            @NotNull final BaseVariant variant) {
+        
+        GnagCheckTask.addToProject(project, gnagPluginExtension, variant);
+        GnagReportTask.addToProject(project, gnagPluginExtension.github, variant);
+    }
+    
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
@@ -44,7 +44,7 @@ public class GnagCheckTask extends DefaultTask {
 
     public static final String TASK_NAME_PREFIX = "gnagCheck";
 
-    public static void addToProject(
+    public static Task addToProject(
             @NotNull final Project project,
             @NotNull final GnagPluginExtension gnagPluginExtension,
             @NotNull final BaseVariant variant) {
@@ -65,6 +65,8 @@ public class GnagCheckTask extends DefaultTask {
         gnagCheckTask.violationDetectors.add(new PMDViolationDetector(project, gnagPluginExtension.pmd));
         gnagCheckTask.violationDetectors.add(new FindbugsViolationDetector(project, gnagPluginExtension.findbugs));
         gnagCheckTask.violationDetectors.add(new AndroidLintViolationDetector(project, gnagPluginExtension.androidLint));
+
+        return gnagCheckTask;
     }
     
     @NotNull

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
@@ -44,7 +44,7 @@ public class GnagReportTask extends DefaultTask {
     public static final String TASK_NAME_PREFIX = "gnagReport";
     private static final String REMOTE_SUCCESS_COMMENT_FORMAT_STRING = "Congrats, no :poop: code found%s!";
 
-    public static void addToProject(
+    public static Task addToProject(
             @NotNull final Project project,
             @NotNull final GitHubExtension gitHubExtension,
             @NotNull final BaseVariant variant) {
@@ -61,6 +61,8 @@ public class GnagReportTask extends DefaultTask {
         GnagReportTask gnagReportTask = (GnagReportTask) project.task(taskOptions, getTaskNameForBuildVariant(variant));
         gnagReportTask.dependsOn(GnagCheckTask.getTaskNameForBuildVariant(variant));
         gnagReportTask.setGitHubExtension(gitHubExtension);
+        
+        return gnagReportTask;
     }
 
     @NotNull

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/StringUtils.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/StringUtils.java
@@ -46,9 +46,22 @@ public final class StringUtils {
 
         return nullableSanitizedString != null ? nullableSanitizedString : "";
     }
+    
+    @NotNull
+    public static String capitalizeFirstChar(@NotNull final String string) {
+        return string.substring(0, 1).toUpperCase() + string.substring(1);
+    }
+
+    public static boolean isBlank(@Nullable final String string) {
+        return string == null || string.trim().isEmpty();
+    }
+
+    public static boolean isNotBlank(@Nullable final String string) {
+        return !isBlank(string);
+    }
 
     private StringUtils() {
         // This constructor intentionally left blank.
     }
-
+    
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationFormatter.java
@@ -16,7 +16,6 @@
 package com.btkelly.gnag.utils;
 
 import com.btkelly.gnag.models.Violation;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;

--- a/version.gradle
+++ b/version.gradle
@@ -1,1 +1,1 @@
-project.ext.gnagPluginVersion = '1.2.1'
+project.ext.gnagPluginVersion = '1.3.0-LOCAL'


### PR DESCRIPTION
@btkelly here's a first attempt at adding support for build variants. Stuff basically works! There are some interesting challenges remaining, outlined below - let's talk through them next week.

The new tasks generated for the example project are shown below:

<img width="1440" alt="screen shot 2016-10-15 at 9 54 45 pm" src="https://cloud.githubusercontent.com/assets/6463980/19414680/b348c294-9322-11e6-974b-566f187c8a0a.png">

The global `gnagCheck` task straight-up just depends on all the variant tasks right now. Because of how we're marking the build status in the per-variant versions of this task, execution stops as soon as gnag detects a violation for _any_ of the build types it's running on. Not sure if this is desirable behavior? If not, I have a rough workaround in mind that will involve checking if any other `gnagCheck*` tasks are present in the graph, but it's not obvious to me exactly _when_ we'd want to fail the build...

In that case, we'd also need to disambiguate output from the variant tasks. In fact, we may want to do this anyway to make it clear which variant produced a failure. For example, we'd probably want our output to be transformed from

``` text
checkstyle_report.xml
findbugs.xml
github-markdown.css
gnag.html
pmd.xml
```

to

``` text
checkstyle_report_debug.xml
checkstyle_report_release.xml
findbugs_debug.xml
findbugs_release.xml
github-markdown.css
gnag_debug.html
gnag_release.html
pmd_debug.xml
pmd_release.xml
```

and corresponding log messages to be updated, etc.

Feedback welcome, as always!

![bitmoji](https://render.bitstrips.com/v2/cpanel/9941846-120874784_9-s1-v1.png?transparent=1&width=246)
