### PR TITLE
Fix intra-file comment ordering in aggregated comments

### DIFF
--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -24,25 +24,38 @@ import java.util.List;
 
 public final class Violation {
 
-    /**
-     * WARNING: do not use this comparator to sort Violations with missing or partial location information only!
-     *
-     * Violations that will be reported as inline comments should be reported in the order specified by this Comparator.
-     * Comments will be sorted first by relative file path, then within each file by line number.
-     */
-    @SuppressWarnings("ConstantConditions")
-    public static final Comparator<Violation> COMMENT_POSTING_COMPARATOR = (v1, v2) -> {
-        if (!v1.hasAllLocationInfo() || !v2.hasAllLocationInfo()) {
-            return 0;
-        }
-
+    @NotNull
+    public static final Comparator<Violation> COMPARATOR = (v1, v2) -> {
+        // Primary grouping is based on file paths:
+        
         final String v1RelativeFilePath = v1.getRelativeFilePath();
         final String v2RelativeFilePath = v2.getRelativeFilePath();
 
-        if (v1RelativeFilePath.equals(v2RelativeFilePath)) {
-            return v1.getFileLineNumber().compareTo(v2.getFileLineNumber());
-        } else {
+        if (v1RelativeFilePath == null && v2RelativeFilePath == null) {
+            return 0;
+        } else if (v1RelativeFilePath == null) {
+            return -1;
+        } else if (v2RelativeFilePath == null) {
+            return 1;
+        }
+        
+        if (!v1RelativeFilePath.equals(v2RelativeFilePath)) {
             return v1RelativeFilePath.compareTo(v2RelativeFilePath);
+        }
+
+        // Secondary grouping is based on line numbers:
+
+        final Integer v1FileLineNumber = v1.getFileLineNumber();
+        final Integer v2FileLineNumber = v2.getFileLineNumber();
+
+        if (v1FileLineNumber == null && v2FileLineNumber == null) {
+            return 0;
+        } else if (v1FileLineNumber == null) {
+            return -1;
+        } else if (v2FileLineNumber == null) {
+            return 1;
+        } else {
+            return v1FileLineNumber.compareTo(v2FileLineNumber);
         }
     };
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/Violation.java
@@ -26,6 +26,7 @@ public final class Violation {
 
     @NotNull
     public static final Comparator<Violation> COMPARATOR = (v1, v2) -> {
+
         // Primary grouping is based on file paths:
         
         final String v1RelativeFilePath = v1.getRelativeFilePath();
@@ -34,9 +35,9 @@ public final class Violation {
         if (v1RelativeFilePath == null && v2RelativeFilePath == null) {
             return 0;
         } else if (v1RelativeFilePath == null) {
-            return -1;
-        } else if (v2RelativeFilePath == null) {
             return 1;
+        } else if (v2RelativeFilePath == null) {
+            return -1;
         }
         
         if (!v1RelativeFilePath.equals(v2RelativeFilePath)) {
@@ -51,9 +52,9 @@ public final class Violation {
         if (v1FileLineNumber == null && v2FileLineNumber == null) {
             return 0;
         } else if (v1FileLineNumber == null) {
-            return -1;
-        } else if (v2FileLineNumber == null) {
             return 1;
+        } else if (v2FileLineNumber == null) {
+            return -1;
         } else {
             return v1FileLineNumber.compareTo(v2FileLineNumber);
         }

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
@@ -30,10 +30,11 @@ import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 import static com.btkelly.gnag.models.GitHubStatusType.*;
+import static com.btkelly.gnag.models.Violation.COMPARATOR;
 import static java.lang.Math.min;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Created by bobbake4 on 4/1/16.
@@ -47,10 +48,10 @@ public class GnagReportTask extends DefaultTask {
         Map<String, Object> taskOptions = new HashMap<>();
 
         taskOptions.put(Task.TASK_NAME, TASK_NAME);
-        taskOptions.put(Task.TASK_TYPE, GnagReportTask.class);
-        taskOptions.put(Task.TASK_GROUP, "Verification");
-        taskOptions.put(Task.TASK_DEPENDS_ON, "check");
-        taskOptions.put(Task.TASK_DESCRIPTION, "Runs Gnag and generates a report to publish to GitHub and set the status of a PR");
+        taskOptions.put(TASK_TYPE, GnagReportTask.class);
+        taskOptions.put(TASK_GROUP, "Verification");
+        taskOptions.put(TASK_DEPENDS_ON, "check");
+        taskOptions.put(TASK_DESCRIPTION, "Runs Gnag and generates a report to publish to GitHub and set the status of a PR");
 
         GnagReportTask gnagReportTask = (GnagReportTask) project.task(taskOptions, TASK_NAME);
         gnagReportTask.dependsOn(GnagCheck.TASK_NAME);
@@ -144,7 +145,7 @@ public class GnagReportTask extends DefaultTask {
             }
         }
 
-        violationsWithValidLocationInfo.sort(Violation.COMMENT_POSTING_COMPARATOR);
+        violationsWithValidLocationInfo.sort(COMPARATOR);
 
         violationsWithValidLocationInfo.stream()
                 .forEach(violation -> gitHubApi.postGitHubInlineCommentSync(
@@ -158,7 +159,7 @@ public class GnagReportTask extends DefaultTask {
                  * Try to post the aggregate comment _strictly after_ all individual comments. GitHub seems to round
                  * post times to the nearest second, so delaying by one whole second should be sufficient here.
                  */
-                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+                Thread.sleep(SECONDS.toMillis(1));
             } catch (final InterruptedException e) {
                 e.printStackTrace();
             }

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationsFormatter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ViolationsFormatter.java
@@ -23,25 +23,30 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.btkelly.gnag.models.Violation.COMPARATOR;
+
 /**
  * Creates formatted HTML strings representing collections of violations.
  */
 public final class ViolationsFormatter {
 
     public static String getHtmlStringForAggregatedComment(@NotNull final Set<Violation> violations) {
-        final Map<String, List<Violation>> groupedViolations = violations
+        final Map<String, List<Violation>> reporterViolationsMap = violations
                 .stream()
                 .collect(Collectors.groupingBy(Violation::getReporterName));
 
         final HtmlStringBuilder builder = new HtmlStringBuilder();
 
-        for (final Map.Entry<String, List<Violation>> entry : groupedViolations.entrySet()) {
+        for (final Map.Entry<String, List<Violation>> entry : reporterViolationsMap.entrySet()) {
             builder
                     .append("<h2>")
                     .append(entry.getKey() + " Violations")
                     .append("</h2>");
 
-            for (final Violation violation : entry.getValue()) {
+            final List<Violation> reporterViolations = entry.getValue();
+            reporterViolations.sort(COMPARATOR);
+
+            for (final Violation violation : reporterViolations) {
                 builder
                         .append(ViolationFormatter.getHtmlStringForAggregatedComment(violation))
                         .insertLineBreak()


### PR DESCRIPTION
Fixes #132 

`master` allows weird ordering, for example see https://github.com/stkent/gnag-testing/pull/2#issuecomment-230483971.

Now the ordering is fixed, for example see https://github.com/stkent/gnag-testing/pull/2#issuecomment-259329795.

The order in which individual comments are posted to GitHub should be unchanged.