### PR TITLE
Fix exception when using default PMD config

### DIFF
--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
@@ -20,6 +20,7 @@ import com.btkelly.gnag.models.Violation
 
 import groovy.util.slurpersupport.GPathResult
 import net.sourceforge.pmd.ant.PMDTask
+import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
 
 import static com.btkelly.gnag.utils.StringUtils.sanitizePreservingNulls
@@ -46,7 +47,11 @@ class PMDViolationDetector extends BaseExecutedViolationDetector {
         if (reporterExtension.hasReporterConfig()) {
             pmdTask.ruleSetFiles = reporterExtension.getReporterConfig().toString()
         } else {
-            pmdTask.ruleSetFiles = getClass().getClassLoader().getResource("pmd.xml").toString()
+            final InputStream defaultPmdRulesInputStream = getClass().getClassLoader().getResourceAsStream("pmd.xml")
+            final File tempPmdRuleSetFile = File.createTempFile("pmdRuleSetFile", null)
+            tempPmdRuleSetFile.deleteOnExit()
+            FileUtils.copyInputStreamToFile(defaultPmdRulesInputStream, tempPmdRuleSetFile)
+            pmdTask.ruleSetFiles = tempPmdRuleSetFile
         }
 
         reportHelper.getAndroidSources().findAll { it.exists() }.each {


### PR DESCRIPTION
Fixes #94 

Creates a temporary file on disk that contains the default PMD configuration, then passes a reference to this file to [setRuleSetFiles](https://pmd.github.io/pmd-5.5.3/apidocs/). For some reason there's no need to convert the `File` to a path or similar; maybe Groovy auto-calls `toString` on the argument or something? 🤷‍♂️ 

On my system, file was created at a path like:

    /var/folders/tn/8kcqbqjx1cb7bj9z6vzs91mw0000gn/T/pmdRuleSetFile1021182419528870073.tmp

and was automatically cleaned up after each invocation of the plugin.