### PR TITLE
Update Android Gradle plugin to 2.3.0

### DIFF
--- a/example-android/build.gradle
+++ b/example-android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/example-android/gradle.properties
+++ b/example-android/gradle.properties
@@ -9,8 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
The stable version of Android Studio 2.3.0 and the matching Android Gradle plugin `2.3.0` were released today.

https://android-developers.googleblog.com/2017/03/android-studio-2-3.html

It also increases the max heap space to 1536M, to allow `dex` to run in process (this was missing from 1247fb8).