### PR TITLE
Update README.md with info about all reporters being enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ gnag {
 }
 ```
 
+***NOTE:*** All reporters are enabled by default
+
 - ***enabled*** - easily disable Gnag in specific situations
 - ***failOnError*** - should violations cause the build to fail or just generate a report
 - ***checkstyle*** - block to customize the checkstyle reporter


### PR DESCRIPTION
If I'm reading the source code correctly all reporters are enabled by default. This commit adds info about that to the README.md.