### PR TITLE
[New] Add extra configuration for GitHub reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ gnag {
         repoName 'btkelly/repo'
         authToken '0000000000000'
         issueNumber '1'
+        commentInline true
+        commentOnSuccess true
     }
 }
 ```
@@ -175,6 +177,8 @@ gnag {
         repoName("btkelly/repo")
         authToken("0000000000000")
         issueNumber("1")
+        commentInline true
+        commentOnSuccess true
     }
 }
 ```
@@ -208,6 +212,8 @@ gnag {
   - ***repoName*** - account and repo name to report violations to
   - ***authToken*** - a GitHub token for a user that has access to comment on issues to the specified repo
   - ***issueNumber*** - the issue or PR number currently being built
+  - ***commentInline*** - whether or not comments posted to GitHub should be placed inline where possible
+  - ***commentOnSuccess*** - whether or not a comment should be posted to GitHub when no violations exist
 
 ## Example Output
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/extensions/GitHubExtension.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/extensions/GitHubExtension.java
@@ -20,7 +20,7 @@ import org.gradle.api.Project;
 /**
  * Created by bobbake4 on 4/18/16.
  */
-public class GitHubExtension {
+public final class GitHubExtension {
 
     private final Project project;
 
@@ -28,8 +28,10 @@ public class GitHubExtension {
     private String repoName;
     private String authToken;
     private String issueNumber;
+    private boolean commentInline = true;
+    private boolean commentOnSuccess = true;
 
-    public GitHubExtension(Project project) {
+    GitHubExtension(Project project) {
         this.project = project;
     }
 
@@ -65,6 +67,22 @@ public class GitHubExtension {
         return project.hasProperty("issueNumber") ? (String) project.property("issueNumber") : issueNumber;
     }
 
+    public boolean isCommentInline() {
+        return commentInline;
+    }
+
+    public void setCommentInline(final boolean commentInline) {
+        this.commentInline = commentInline;
+    }
+
+    public boolean isCommentOnSuccess() {
+        return commentOnSuccess;
+    }
+
+    public void setCommentOnSuccess(final boolean commentOnSuccess) {
+        this.commentOnSuccess = commentOnSuccess;
+    }
+
     @Override
     public String toString() {
         return "GitHubExtension{" +
@@ -73,6 +91,8 @@ public class GitHubExtension {
                 ", repoName='" + repoName + '\'' +
                 ", authToken='" + authToken + '\'' +
                 ", issueNumber='" + issueNumber + '\'' +
+                ", commentInline=" + commentInline +
+                ", commentOnSuccess=" + commentOnSuccess +
                 '}';
     }
 }


### PR DESCRIPTION
Adds two new options to the GitHub extension:

  - `commentInline` - whether or not comments posted to GitHub should be placed inline where possible
  - `commentOnSuccess` - whether or not a comment should be posted to GitHub when no violations exist

This change should be purely additive and backwards compatible with existing Gnag configurations.