### PR TITLE
Improved logging

### DIFF
--- a/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.logging.LogLevel
  */
 class GnagPlugin implements Plugin<Project> {
 
-    public static final LogLevel STD_OUT_LOG_LEVEL = LogLevel.INFO
+    public static final LogLevel STD_OUT_LOG_LEVEL = LogLevel.DEBUG
     public static final LogLevel STD_ERR_LOG_LEVEL = LogLevel.ERROR
 
     @Override

--- a/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
@@ -19,16 +19,25 @@ import com.btkelly.gnag.extensions.GnagPluginExtension
 import com.btkelly.gnag.tasks.GnagCheckTask
 import com.btkelly.gnag.tasks.GnagReportTask
 import com.btkelly.gnag.utils.ProjectHelper
+import org.gradle.api.AntBuilder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.logging.LogLevel
 
 /**
  * Created by bobbake4 on 4/1/16.
  */
 class GnagPlugin implements Plugin<Project> {
 
+    public static final LogLevel STD_OUT_LOG_LEVEL = LogLevel.INFO
+    public static final LogLevel STD_ERR_LOG_LEVEL = LogLevel.ERROR
+
     @Override
     void apply(Project project) {
+        project.logging.captureStandardOutput(STD_OUT_LOG_LEVEL)
+        project.logging.captureStandardError(STD_ERR_LOG_LEVEL)
+        project.ant.setLifecycleLogLevel(AntBuilder.AntMessagePriority.ERROR)
+
         GnagPluginExtension gnagPluginExtension = GnagPluginExtension.loadExtension(project)
 
         project.repositories.jcenter() // Unlikely to be missing in real projects; here for sample projects only.

--- a/plugin/src/main/groovy/com/btkelly/gnag/api/GitHubApi.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/api/GitHubApi.java
@@ -22,10 +22,10 @@ import com.btkelly.gnag.utils.gson.GsonConverterFactory;
 import com.github.stkent.githubdiffparser.models.Diff;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.LoggerFactory;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -45,18 +45,19 @@ public class GitHubApi {
     private final GitHubApiClient gitHubApiClient;
     private final GitHubExtension gitHubExtension;
     private final Executor singleThreadExecutor;
+    private final Logger logger;
 
-    public GitHubApi(final GitHubExtension gitHubExtension) {
+    public GitHubApi(final GitHubExtension gitHubExtension, Logger logger) {
         this.gitHubExtension = gitHubExtension;
         this.singleThreadExecutor = Executors.newSingleThreadExecutor();
+        this.logger = logger;
 
-        org.slf4j.Logger gradleLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        HttpLoggingInterceptor.Logger logger = gradleLogger::info;
+        HttpLoggingInterceptor.Logger loggingInterceptor = logger::debug;
 
         OkHttpClient okHttpClient = new OkHttpClient.Builder()
                 .addInterceptor(new UserAgentInterceptor())
                 .addInterceptor(new AuthInterceptor(gitHubExtension.getAuthToken()))
-                .addInterceptor(new HttpLoggingInterceptor(logger).setLevel(HttpLoggingInterceptor.Level.BASIC))
+                .addInterceptor(new HttpLoggingInterceptor(loggingInterceptor).setLevel(Level.BODY))
                 .build();
 
         String baseUrl = gitHubExtension.getRootUrl() + gitHubExtension.getRepoName() + "/";
@@ -72,6 +73,7 @@ public class GitHubApi {
     }
 
     public void postGitHubPRCommentAsync(final String comment) {
+        logger.debug("postGitHubPRCommentAsync: " + comment);
         gitHubApiClient.postPRComment(new GitHubPRComment(comment), gitHubExtension.getIssueNumber())
                 .enqueue(new DefaultCallback<>());
     }
@@ -80,6 +82,9 @@ public class GitHubApi {
             final GitHubStatusType gitHubStatusType,
             final String moduleName,
             final String prSha) {
+        logger.debug("postUpdatedGitHubStatusAsync - Status: " + gitHubStatusType);
+        logger.debug("postUpdatedGitHubStatusAsync - Module Name: " + gitHubStatusType);
+        logger.debug("postUpdatedGitHubStatusAsync - PR Sha: " + gitHubStatusType);
 
         singleThreadExecutor.execute(() -> {
 
@@ -91,7 +96,9 @@ public class GitHubApi {
                     isSuccessful = gitHubApiClient.postUpdatedStatus(new GitHubStatus(gitHubStatusType, moduleName), prSha)
                             .execute()
                             .isSuccessful();
+                    logger.debug("postUpdatedGitHubStatusAsync - isSuccessful: " + isSuccessful + ", retry count: " + retryCount);
                 } catch (IOException e) {
+                    logger.debug("postUpdatedGitHubStatusAsync - Error retry count: " + retryCount, e);
                     e.printStackTrace();
                 }
 
@@ -110,6 +117,8 @@ public class GitHubApi {
                         + gitHubPRDetailsResponse.code() + " " + gitHubPRDetailsResponse.message());
             }
 
+            logger.debug("getPRDetailsSync - response: " + gitHubPRDetailsResponse.body());
+
             return gitHubPRDetailsResponse.body();
         } catch (IOException e) {
             throw new GradleException("Failed to fetch PR details.", e);
@@ -122,8 +131,11 @@ public class GitHubApi {
             final Response<List<Diff>> gitHubPRDiffsResponse
                     = gitHubApiClient.getPRDiffs(gitHubExtension.getIssueNumber()).execute();
 
+            logger.debug("getPRDiffsSync - isSuccessful: " + gitHubPRDiffsResponse.isSuccessful());
+
             return gitHubPRDiffsResponse.body();
         } catch (final Exception e) {
+            logger.debug("getPRDiffsSync - Error", e);
             e.printStackTrace();
             return new ArrayList<>();
         }
@@ -133,17 +145,21 @@ public class GitHubApi {
             @NotNull final String body,
             @NotNull final String prSha,
             @NotNull final PRLocation prLocation) {
+        logger.debug("postGitHubInlineCommentSync - Body: " + body);
+        logger.debug("postGitHubInlineCommentSync - PR Sha: " + prSha);
+        logger.debug("postGitHubInlineCommentSync - PR Location: " + prLocation);
 
         try {
             gitHubApiClient.postInlineComment(
                     new GitHubInlineComment(body, prSha, prLocation), gitHubExtension.getIssueNumber())
                     .execute();
         } catch (final Exception e) {
+            logger.debug("postGitHubInlineCommentSync - Error", e);
             e.printStackTrace();
         }
     }
 
-    private static final class DefaultCallback<T> implements Callback<T> {
+    private final class DefaultCallback<T> implements Callback<T> {
 
         private DefaultCallback() {
             // This constructor intentionally left blank.
@@ -151,11 +167,12 @@ public class GitHubApi {
 
         @Override
         public void onResponse(final Call<T> call, final Response<T> response) {
-            // This method intentionally left blank.
+            logger.debug(call.toString() + " - onResponse" + response);
         }
 
         @Override
         public void onFailure(final Call<T> call, final Throwable t) {
+            logger.debug(call.toString() + " - onFailure", t);
             t.printStackTrace();
         }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/models/PRLocation.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/models/PRLocation.java
@@ -38,4 +38,10 @@ public final class PRLocation {
         return diffLineIndex;
     }
 
+    @Override public String toString() {
+        return "PRLocation{" +
+               "relativeFilePath='" + relativeFilePath + '\'' +
+               ", diffLineIndex=" + diffLineIndex +
+               '}';
+    }
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -74,7 +74,8 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
                 final Integer lineNumber = LineNumberParser.parseLineNumberString(
                         lineNumberString,
                         name(),
-                        violationType)
+                        violationType,
+                        project.getLogger())
 
                 final List<String> secondaryUrls = computeSecondaryUrls(
                         sanitizePreservingNulls((String) violation.@urls.text()),

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
@@ -127,7 +127,8 @@ class FindbugsViolationDetector extends BaseExecutedViolationDetector {
                 final Integer lineNumber = LineNumberParser.parseLineNumberString(
                         lineNumberString,
                         name(),
-                        violationType)
+                        violationType,
+                        project.getLogger())
 
                 result.add(new Violation(
                         violationType,

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/FindbugsViolationDetector.groovy
@@ -21,7 +21,6 @@ import com.btkelly.gnag.reporters.utils.LineNumberParser
 import com.btkelly.gnag.reporters.utils.PathCalculator
 import edu.umd.cs.findbugs.anttask.FindBugsTask
 import groovy.util.slurpersupport.GPathResult
-import org.apache.commons.io.FilenameUtils
 import org.apache.tools.ant.types.FileSet
 import org.apache.tools.ant.types.Path
 import org.gradle.api.Project
@@ -30,6 +29,7 @@ import java.util.stream.Collectors
 
 import static com.btkelly.gnag.utils.StringUtils.sanitizePreservingNulls
 import static com.btkelly.gnag.utils.StringUtils.sanitizeToNonNull
+
 /**
  * Created by bobbake4 on 4/1/16.
  */

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
@@ -79,7 +79,8 @@ class PMDViolationDetector extends BaseExecutedViolationDetector {
                 final Integer lineNumber = LineNumberParser.parseLineNumberString(
                         lineNumberString,
                         name(),
-                        violationType)
+                        violationType,
+                        project.getLogger())
 
                 result.add(new Violation(
                         violationType,

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/PMDViolationDetector.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.Project
 
 import static com.btkelly.gnag.utils.StringUtils.sanitizePreservingNulls
 import static com.btkelly.gnag.utils.StringUtils.sanitizeToNonNull
+
 /**
  * Created by bobbake4 on 4/1/16.
  */
@@ -38,7 +39,6 @@ class PMDViolationDetector extends BaseExecutedViolationDetector {
 
     @Override
     void executeReporter() {
-
         PMDTask pmdTask = new PMDTask()
         pmdTask.project = project.ant.antProject
         pmdTask.addFormatter(new net.sourceforge.pmd.ant.Formatter(type: 'xml', toFile: reportFile()))

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/utils/CheckstyleParser.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/utils/CheckstyleParser.groovy
@@ -39,7 +39,8 @@ final class CheckstyleParser {
                 final Integer lineNumber = LineNumberParser.parseLineNumberString(
                         lineNumberString,
                         reporterName,
-                        shortViolationName)
+                        shortViolationName,
+                        project.getLogger())
 
                 result.add(new Violation(
                         shortViolationName,

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/utils/LineNumberParser.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/utils/LineNumberParser.groovy
@@ -15,6 +15,8 @@
  */
 package com.btkelly.gnag.reporters.utils
 
+import org.gradle.api.logging.Logger
+
 final class LineNumberParser {
 
     /**
@@ -26,7 +28,8 @@ final class LineNumberParser {
     static Integer parseLineNumberString(
             final String lineNumberString,
             final String reporterName,
-            final String violationType) {
+            final String violationType,
+            final Logger logger) {
 
         if (lineNumberString.isEmpty()) {
             return null
@@ -37,14 +40,14 @@ final class LineNumberParser {
                 if (result >= 0) {
                     return result
                 } else {
-                    System.out.println(
+                    logger.error(
                             "Invalid line number: + " + result +
                                     " for " + reporterName + " violation: " + violationType)
 
                     return null
                 }
             } catch (final NumberFormatException ignored) {
-                System.out.println(
+                logger.error(
                         "Error parsing line number string: \"" + lineNumberString +
                                 "\" for " + reporterName + " violation: " + violationType)
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/DetektTask.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/DetektTask.groovy
@@ -17,6 +17,8 @@ package com.btkelly.gnag.tasks
 
 import com.btkelly.gnag.utils.ProjectHelper
 import org.gradle.api.Task
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.LoggingManager
 import org.gradle.api.tasks.JavaExec
 
 final class DetektTask {
@@ -29,7 +31,7 @@ final class DetektTask {
         taskOptions.put(Task.TASK_GROUP, "Verification")
         taskOptions.put(Task.TASK_DESCRIPTION, "Runs detekt and generates an XML report for parsing by Gnag")
 
-        projectHelper.project.task(taskOptions, "gnagDetekt") { task ->
+        return projectHelper.project.task(taskOptions, "gnagDetekt") { task ->
             main = "io.gitlab.arturbosch.detekt.cli.Main"
             classpath = projectHelper.project.configurations.gnagDetekt
             ignoreExitValue = true

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/DetektTask.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/DetektTask.groovy
@@ -15,11 +15,13 @@
  */
 package com.btkelly.gnag.tasks
 
+
 import com.btkelly.gnag.utils.ProjectHelper
 import org.gradle.api.Task
-import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.LoggingManager
 import org.gradle.api.tasks.JavaExec
+
+import static com.btkelly.gnag.GnagPlugin.STD_ERR_LOG_LEVEL
+import static com.btkelly.gnag.GnagPlugin.STD_OUT_LOG_LEVEL
 
 final class DetektTask {
 
@@ -31,7 +33,7 @@ final class DetektTask {
         taskOptions.put(Task.TASK_GROUP, "Verification")
         taskOptions.put(Task.TASK_DESCRIPTION, "Runs detekt and generates an XML report for parsing by Gnag")
 
-        return projectHelper.project.task(taskOptions, "gnagDetekt") { task ->
+        final Task result = projectHelper.project.task(taskOptions, "gnagDetekt") { task ->
             main = "io.gitlab.arturbosch.detekt.cli.Main"
             classpath = projectHelper.project.configurations.gnagDetekt
             ignoreExitValue = true
@@ -43,6 +45,11 @@ final class DetektTask {
                 args "--config", "$reporterConfig"
             }
         }
+
+        result.logging.captureStandardOutput(STD_OUT_LOG_LEVEL)
+        result.logging.captureStandardError(STD_ERR_LOG_LEVEL)
+
+        return result
     }
 
     private DetektTask() {

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
@@ -114,19 +114,19 @@ public class GnagCheckTask extends DefaultTask {
             final List<Violation> detectedViolations = violationDetector.getDetectedViolations();
             allDetectedViolations.addAll(detectedViolations);
 
-            System.out.println(violationDetector.name() + " detected " + detectedViolations.size() + " violations.");
+            getLogger().lifecycle(violationDetector.name() + " detected " + detectedViolations.size() + " violations.");
         });
 
         final File reportsDir = projectHelper.getReportsDir();
 
         if (allDetectedViolations.isEmpty()) {
-            ReportWriter.deleteLocalReportFiles(reportsDir);
+            ReportWriter.deleteLocalReportFiles(reportsDir, getLogger());
 
             getProject().setStatus(CheckStatus.getSuccessfulCheckStatus());
 
-            System.out.println("Congrats, no poop code found!");
+            getLogger().lifecycle("Congrats, no poop code found!");
         } else {
-            ReportWriter.writeLocalReportFiles(allDetectedViolations, reportsDir);
+            ReportWriter.writeLocalReportFiles(allDetectedViolations, reportsDir, getLogger());
 
             getProject().setStatus(new CheckStatus(FAILURE, allDetectedViolations));
 
@@ -139,7 +139,7 @@ public class GnagCheckTask extends DefaultTask {
             if (gnagPluginExtension.shouldFailOnError() && !taskExecutionGraphIncludesGnagReport()) {
                 throw new GradleException(failedMessage);
             } else {
-                System.out.println(failedMessage);
+                getLogger().lifecycle(failedMessage);
                 throw new StopExecutionException(failedMessage);
             }
         }

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
@@ -98,11 +98,12 @@ public class GnagReportTask extends DefaultTask {
     private void setGitHubExtension(GitHubExtension gitHubExtension) {
         commentInline = gitHubExtension.isCommentInline();
         commentOnSuccess = gitHubExtension.isCommentOnSuccess();
-        gitHubApi = new GitHubApi(gitHubExtension);
+        gitHubApi = new GitHubApi(gitHubExtension, getLogger());
     }
 
     private String getPRSha() {
         if (StringUtils.isBlank(prSha)) {
+            getLogger().debug("getPRSha: fetching...");
             GitHubPRDetails pullRequestDetails = gitHubApi.getPRDetailsSync();
 
             if (pullRequestDetails.getHead() != null) {
@@ -112,10 +113,13 @@ public class GnagReportTask extends DefaultTask {
             }
         }
 
+        getLogger().debug("getPRSha: " + prSha);
+
         return prSha;
     }
 
     private void updatePRStatus(GitHubStatusType gitHubStatusType) {
+        getLogger().debug("Updating PR Status to: " + gitHubStatusType);
         if (StringUtils.isNotBlank(getPRSha())) {
             gitHubApi.postUpdatedGitHubStatusAsync(gitHubStatusType, getProject().getName(), getPRSha());
         }

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
@@ -75,7 +75,7 @@ public class GnagReportTask extends DefaultTask {
 
         if (projectStatus instanceof CheckStatus) {
             final CheckStatus checkStatus = (CheckStatus) projectStatus;
-            System.out.println("Project status: " + checkStatus);
+            getLogger().info("Project status: " + checkStatus);
 
             if (checkStatus.getGitHubStatusType() == SUCCESS) {
                 if (commentOnSuccess) {
@@ -90,7 +90,7 @@ public class GnagReportTask extends DefaultTask {
 
             updatePRStatus(checkStatus.getGitHubStatusType());
         } else {
-            System.out.println("Project status is not instanceof Check Status");
+            getLogger().error("Project status is not instanceof Check Status");
             updatePRStatus(ERROR);
         }
     }
@@ -108,7 +108,7 @@ public class GnagReportTask extends DefaultTask {
             if (pullRequestDetails.getHead() != null) {
                 prSha = pullRequestDetails.getHead().getSha();
             } else {
-                System.out.println("HEAD is null, unable to fetch PR Sha");
+                getLogger().error("HEAD is null, unable to fetch PR Sha");
             }
         }
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/KtlintTask.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/KtlintTask.groovy
@@ -29,12 +29,10 @@ final class KtlintTask {
         taskOptions.put(Task.TASK_GROUP, "Verification")
         taskOptions.put(Task.TASK_DESCRIPTION, "Runs ktlint and generates an XML report for parsing by Gnag")
 
-        projectHelper.project.task(taskOptions, "gnagKtlint") { task ->
+        return projectHelper.project.task(taskOptions, "gnagKtlint") { task ->
             main = "com.github.shyiko.ktlint.Main"
             classpath = projectHelper.project.configurations.gnagKtlint
             ignoreExitValue = true
-            args "--debug"
-            args "--verbose"
             args "--reporter=checkstyle,output=${projectHelper.getKtlintReportFile()}"
 
             projectHelper.kotlinSourceFiles.forEach { sourceFile ->

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ProjectHelper.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ProjectHelper.groovy
@@ -17,6 +17,7 @@ package com.btkelly.gnag.utils
 
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
+import org.gradle.api.logging.Logger
 
 /**
  * Created by bobbake4 on 4/19/16.

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ProjectHelper.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ProjectHelper.groovy
@@ -17,7 +17,6 @@ package com.btkelly.gnag.utils
 
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
 
 /**
  * Created by bobbake4 on 4/19/16.

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ReportWriter.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ReportWriter.java
@@ -17,6 +17,7 @@ package com.btkelly.gnag.utils;
 
 import com.btkelly.gnag.models.Violation;
 import org.apache.commons.io.FileUtils;
+import org.gradle.api.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -42,7 +43,8 @@ public final class ReportWriter {
 
     public static void writeLocalReportFiles(
             @NotNull final Set<Violation> violations,
-            @NotNull final File directory) {
+            @NotNull final File directory,
+            @NotNull final Logger logger) {
         
         if (violations.isEmpty()) {
             System.err.println("writeLocalReportFiles should only be called when violations were detected!");
@@ -61,51 +63,46 @@ public final class ReportWriter {
             final File htmlReportFile = new File(directory, REPORT_FILE_NAME);
             FileUtils.write(htmlReportFile, builder.toString());
         } catch (final IOException e) {
-            System.out.println("Error writing local Gnag report.");
-            e.printStackTrace();
+            logger.error("Error writing local Gnag report.", e);
             return;
         }
 
-        copyCssFileToDirectory(directory);
+        copyCssFileToDirectory(directory, logger);
     }
     
-    public static void deleteLocalReportFiles(@NotNull final File directory) {
+    public static void deleteLocalReportFiles(@NotNull final File directory, @NotNull final Logger logger) {
         final File htmlReportFile = new File(directory, REPORT_FILE_NAME);
         
         if (htmlReportFile.exists()) {
             try {
                 FileUtils.forceDelete(htmlReportFile);
             } catch (final IOException e) {
-                System.out.println("Error deleting local Gnag report.");
-                e.printStackTrace();
+                logger.error("Error deleting local Gnag report.", e);
             }
         }
         
-        deleteCssFileFromDirectory(directory);
+        deleteCssFileFromDirectory(directory, logger);
     }
 
-    private static void copyCssFileToDirectory(@NotNull final File directory) {
+    private static void copyCssFileToDirectory(@NotNull final File directory, @NotNull final Logger logger) {
         try {
             //TODO fix this
             final InputStream resourceAsStream = ReportWriter.class.getClassLoader().getResourceAsStream(CSS_FILE_NAME);
             final File gnagCssOutputFile = new File(directory, CSS_FILE_NAME);
             FileUtils.copyInputStreamToFile(resourceAsStream, gnagCssOutputFile);
-
         } catch (final Exception e) {
-            System.out.println("Error copying CSS file for local Gnag report.");
-            e.printStackTrace();
+            logger.error("Error copying CSS file for local Gnag report.", e);
         }
     }
 
-    private static void deleteCssFileFromDirectory(@NotNull final File directory) {
+    private static void deleteCssFileFromDirectory(@NotNull final File directory, @NotNull final Logger logger) {
         final File gnagCssOutputFile = new File(directory, CSS_FILE_NAME);
 
         if (gnagCssOutputFile.exists()) {
             try {
                 FileUtils.forceDelete(gnagCssOutputFile);
             } catch (final IOException e) {
-                System.out.println("Error deleting CSS file for local Gnag report.");
-                e.printStackTrace();
+                logger.error("Error deleting CSS file for local Gnag report.");
             }
         }
     }

--- a/version.gradle
+++ b/version.gradle
@@ -1,4 +1,4 @@
-project.ext.gnagPluginVersion = '2.2.0'
+project.ext.gnagPluginVersion = '2.2.1-RC1'
 project.ext.gnagPackageId = 'com.btkelly.gnag'
 project.ext.gnagArtifactId = 'gnag'
 project.ext.gnagPluginName = 'gnag-gradle-plugin'


### PR DESCRIPTION
- Updates to use the Gradle logging system and levels for all Gnag-generated log messages
- Redirects noisy output from the tools that Gnag includes where possible. 
    - redirects std out to Gradle log level `INFO`
    - redirects std err to Gradle log level `ERROR`
    - redirects ant task ERROR logs to Gradle log level `LIFECYCLE`
    - redirects ant task WARNING and lower logs to Gradle log level `?` < `LIFECYCLE`
    Anyone who needs to see the full output from the tools embedded in Gnag can run the same Gradle command as they usually do, adding the `--info` flag:
    https://docs.gradle.org/current/userguide/logging.html#sec:choosing_a_log_level

This work is in preparation for adding debugging log messages to the Gnag tool itself, which will be logged at Gradle log level `DEBUG`.

---

Sample output with new log levels (I'm assuming :app:gnagDetekt does not show up because it has no corresponding output, but we can see it still executes because it detects a violation):

```none
$ ./gradlew app:gnagReport

> Configure project :app
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation' and 'testApi'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'testApi' is obsolete and has been replaced with 'testImplementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

> Task :app:lint
Ran lint on variant release: 3 issues found
Ran lint on variant debug: 3 issues found
Wrote HTML report to file:///Users/stkent/dev/personal/libraries/gnag-testing/app/build/reports/lint-results.html
Wrote XML report to file:///Users/stkent/dev/personal/libraries/gnag-testing/app/build/reports/lint-results.xml

> Task :app:gnagKtlint
"checkstyle" report written to /Users/stkent/dev/personal/libraries/gnag-testing/app/build/outputs/gnag/ktlint_report.xml

> Task :app:gnagCheck
Checkstyle detected 4 violations.
PMD detected 16 violations.
Executing findbugs FindBugsTask from ant task
[ant:null] Java Result: 3
Findbugs detected 1 violations.
ktlint detected 8 violations.
detekt detected 4 violations.
Android Lint detected 3 violations.
One or more violation detectors has found violations. Check the report at /Users/stkent/dev/personal/libraries/gnag-testing/app/build/outputs/gnag/gnag.html for details.

> Task :app:gnagReport FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:gnagReport'.
> Failed to fetch PR details. Reason: 401 Unauthorized

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 18s
45 actionable tasks: 5 executed, 40 up-to-date
```