### PR TITLE
Add new useGitHubStatus property

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ In this example the issue number and authtoken for the comment user are passed a
 gnag {
     enabled true
     failOnError true
-    useGitHubStatuses true
     
     checkstyle {
         enabled true
@@ -129,6 +128,7 @@ gnag {
         issueNumber '1'
         setCommentInline true
         setCommentOnSuccess true
+        useGitHubStatuses true
     }
 }
 ```
@@ -142,7 +142,6 @@ gnag {
 gnag {
     isEnabled = true
     setFailOnError(true)
-    useGitHubStatuses(true)
 
     checkstyle {
         isEnabled = true
@@ -181,6 +180,7 @@ gnag {
         issueNumber("1")
         setCommentInline(true)
         setCommentOnSuccess(true)
+        useGitHubStatuses(true)
     }
 }
 ```
@@ -191,7 +191,6 @@ gnag {
 
 - ***enabled*** - easily disable Gnag in specific situations
 - ***failOnError*** - should violations cause the build to fail or just generate a report
-- ***useGitHubStatuses*** - should report GitHub status on each module in the PR or just fail if ***failOnError*** enabled
 - ***checkstyle*** - block to customize the checkstyle reporter
   - ***enabled*** - set if checkstyle should execute
   - ***reporterConfig*** - provide a custom [checkstyle config](http://checkstyle.sourceforge.net/config.html)
@@ -217,6 +216,7 @@ gnag {
   - ***issueNumber*** - the issue or PR number currently being built
   - ***setCommentInline*** - whether or not comments posted to GitHub should be placed inline where possible
   - ***setCommentOnSuccess*** - whether or not a comment should be posted to GitHub when no violations exist
+  - ***useGitHubStatuses*** - should report GitHub status on each module in the PR or just fail if ***failOnError*** enabled
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ In this example the issue number and authtoken for the comment user are passed a
 gnag {
     enabled true
     failOnError true
+    useGitHubStatuses true
     
     checkstyle {
         enabled true
@@ -141,6 +142,7 @@ gnag {
 gnag {
     isEnabled = true
     setFailOnError(true)
+    useGitHubStatuses(true)
 
     checkstyle {
         isEnabled = true
@@ -189,6 +191,7 @@ gnag {
 
 - ***enabled*** - easily disable Gnag in specific situations
 - ***failOnError*** - should violations cause the build to fail or just generate a report
+- ***useGitHubStatuses*** - should report GitHub status on each module in the PR or just fail if ***failOnError*** enabled
 - ***checkstyle*** - block to customize the checkstyle reporter
   - ***enabled*** - set if checkstyle should execute
   - ***reporterConfig*** - provide a custom [checkstyle config](http://checkstyle.sourceforge.net/config.html)

--- a/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
@@ -50,7 +50,7 @@ class GnagPlugin implements Plugin<Project> {
             ProjectHelper projectHelper = new ProjectHelper(evaluatedProject)
 
             GnagCheckTask.addTask(projectHelper, gnagPluginExtension)
-            GnagReportTask.addTask(projectHelper, gnagPluginExtension.github)
+            GnagReportTask.addTask(projectHelper, gnagPluginExtension)
         }
     }
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/extensions/GitHubExtension.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/extensions/GitHubExtension.java
@@ -30,6 +30,7 @@ public final class GitHubExtension {
   private String issueNumber;
   private boolean commentInline = true;
   private boolean commentOnSuccess = true;
+  private boolean useGitHubStatuses = true;
 
   GitHubExtension(Project project) {
     this.project = project;
@@ -85,6 +86,15 @@ public final class GitHubExtension {
     this.commentOnSuccess = commentOnSuccess;
   }
 
+  public void setUseGitHubStatuses(boolean useGitHubStatuses) {
+    this.useGitHubStatuses = useGitHubStatuses;
+  }
+
+  public boolean shouldUseGitHubStatuses() {
+    return project.hasProperty("useGitHubStatuses") ? (Boolean) project.property("useGitHubStatuses")
+            : useGitHubStatuses;
+  }
+
   @Override
   public String toString() {
     return "GitHubExtension{" +
@@ -95,6 +105,7 @@ public final class GitHubExtension {
         ", issueNumber='" + issueNumber + '\'' +
         ", commentInline=" + commentInline +
         ", commentOnSuccess=" + commentOnSuccess +
+        ", useGitHubStatuses=" + useGitHubStatuses +
         '}';
   }
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/extensions/GnagPluginExtension.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/extensions/GnagPluginExtension.java
@@ -35,6 +35,7 @@ public class GnagPluginExtension {
   public AndroidLintExtension androidLint;
   private boolean enabled = true;
   private boolean failOnError = true;
+  private boolean useGitHubStatuses = true;
 
   public GnagPluginExtension(@NotNull Project project) {
     this.project = project;
@@ -91,9 +92,18 @@ public class GnagPluginExtension {
     this.failOnError = failOnError;
   }
 
+  public void setUseGitHubStatuses(boolean useGitHubStatuses) {
+    this.useGitHubStatuses = useGitHubStatuses;
+  }
+
   public boolean shouldFailOnError() {
     return project.hasProperty("failOnError") ? (Boolean) project.property("failOnError")
         : failOnError;
+  }
+
+  public boolean shouldUseGitHubStatuses() {
+    return project.hasProperty("useGitHubStatuses") ? (Boolean) project.property("useGitHubStatuses")
+        : useGitHubStatuses;
   }
 
   @Override

--- a/plugin/src/main/groovy/com/btkelly/gnag/extensions/GnagPluginExtension.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/extensions/GnagPluginExtension.java
@@ -35,7 +35,6 @@ public class GnagPluginExtension {
   public AndroidLintExtension androidLint;
   private boolean enabled = true;
   private boolean failOnError = true;
-  private boolean useGitHubStatuses = true;
 
   public GnagPluginExtension(@NotNull Project project) {
     this.project = project;
@@ -92,18 +91,9 @@ public class GnagPluginExtension {
     this.failOnError = failOnError;
   }
 
-  public void setUseGitHubStatuses(boolean useGitHubStatuses) {
-    this.useGitHubStatuses = useGitHubStatuses;
-  }
-
   public boolean shouldFailOnError() {
     return project.hasProperty("failOnError") ? (Boolean) project.property("failOnError")
         : failOnError;
-  }
-
-  public boolean shouldUseGitHubStatuses() {
-    return project.hasProperty("useGitHubStatuses") ? (Boolean) project.property("useGitHubStatuses")
-        : useGitHubStatuses;
   }
 
   @Override

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
@@ -118,8 +118,8 @@ public class GnagReportTask extends DefaultTask {
 
   private void setGnagPluginExtension(GnagPluginExtension gnagPluginExtension) {
     failOnError = gnagPluginExtension.shouldFailOnError();
-    useGitHubStatuses = gnagPluginExtension.shouldUseGitHubStatuses();
     GitHubExtension gitHubExtension = gnagPluginExtension.github;
+    useGitHubStatuses = gitHubExtension.shouldUseGitHubStatuses();
     commentInline = gitHubExtension.isCommentInline();
     commentOnSuccess = gitHubExtension.isCommentOnSuccess();
     gitHubApi = new GitHubApi(gitHubExtension, getLogger());

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagReportTask.java
@@ -15,15 +15,14 @@
  */
 package com.btkelly.gnag.tasks;
 
-import static com.btkelly.gnag.models.GitHubStatusType.ERROR;
-import static com.btkelly.gnag.models.GitHubStatusType.PENDING;
-import static com.btkelly.gnag.models.GitHubStatusType.SUCCESS;
+import static com.btkelly.gnag.models.GitHubStatusType.*;
 import static com.btkelly.gnag.models.Violation.COMPARATOR;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.btkelly.gnag.GnagPlugin;
 import com.btkelly.gnag.api.GitHubApi;
 import com.btkelly.gnag.extensions.GitHubExtension;
+import com.btkelly.gnag.extensions.GnagPluginExtension;
 import com.btkelly.gnag.models.CheckStatus;
 import com.btkelly.gnag.models.GitHubPRDetails;
 import com.btkelly.gnag.models.GitHubStatusType;
@@ -42,10 +41,12 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.annotations.NotNull;
 
@@ -58,10 +59,12 @@ public class GnagReportTask extends DefaultTask {
   private static final String REMOTE_SUCCESS_COMMENT_FORMAT_STRING = "Congrats, no :poop: code found in the **%s** module%s!";
   private boolean commentInline;
   private boolean commentOnSuccess;
+  private boolean useGitHubStatuses;
+  private boolean failOnError;
   private GitHubApi gitHubApi;
   private String prSha;
 
-  public static void addTask(ProjectHelper projectHelper, GitHubExtension gitHubExtension) {
+  public static void addTask(ProjectHelper projectHelper, GnagPluginExtension gnagPluginExtension) {
     Map<String, Object> taskOptions = new HashMap<>();
 
     taskOptions.put(Task.TASK_NAME, TASK_NAME);
@@ -75,7 +78,7 @@ public class GnagReportTask extends DefaultTask {
 
     GnagReportTask gnagReportTask = (GnagReportTask) project.task(taskOptions, TASK_NAME);
     gnagReportTask.dependsOn(GnagCheckTask.TASK_NAME);
-    gnagReportTask.setGitHubExtension(gitHubExtension);
+    gnagReportTask.setGnagPluginExtension(gnagPluginExtension);
   }
 
   @SuppressWarnings("unused")
@@ -113,7 +116,10 @@ public class GnagReportTask extends DefaultTask {
     return Logging.getLogger(GnagPlugin.class);
   }
 
-  private void setGitHubExtension(GitHubExtension gitHubExtension) {
+  private void setGnagPluginExtension(GnagPluginExtension gnagPluginExtension) {
+    failOnError = gnagPluginExtension.shouldFailOnError();
+    useGitHubStatuses = gnagPluginExtension.shouldUseGitHubStatuses();
+    GitHubExtension gitHubExtension = gnagPluginExtension.github;
     commentInline = gitHubExtension.isCommentInline();
     commentOnSuccess = gitHubExtension.isCommentOnSuccess();
     gitHubApi = new GitHubApi(gitHubExtension, getLogger());
@@ -133,8 +139,18 @@ public class GnagReportTask extends DefaultTask {
 
   private void updatePRStatus(GitHubStatusType gitHubStatusType) {
     getLogger().debug("Updating PR Status to: " + gitHubStatusType);
-    if (StringUtils.isNotBlank(getPRSha())) {
-      gitHubApi.postUpdatedGitHubStatus(gitHubStatusType, getProject().getName(), getPRSha());
+    if (useGitHubStatuses) {
+      if (StringUtils.isNotBlank(getPRSha())) {
+        gitHubApi.postUpdatedGitHubStatus(gitHubStatusType, getProject().getName(), getPRSha());
+      }
+    } else {
+      if (gitHubStatusType == ERROR || gitHubStatusType == FAILURE) {
+        if (failOnError) {
+          throw new GradleException(gitHubStatusType.getDescription());
+        } else {
+          throw new StopExecutionException(gitHubStatusType.getDescription());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This is a very good library, which I really like.

I and most of my friends use Circleci, where there is a free mode. In Circleci there is a very convenient workflow, where the next task does not start until the dependent ones are not success. But gnagReport completes the task successfully even if there are violations. Because of this, it can deploy, but the code is not correct.
I added an additional parameter to ***useGitHubStatus***, which is true by default.
If ***useGitHubStatus*** is false and ***failOnError*** is enabled, the job will fail

If you have questions and suggestions, write:)