### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,34 @@ gnag {
 ***NOTE:*** All reporters are enabled by default
 
 - ***enabled*** - easily disable Gnag in specific situations
-- ***failOnError*** - should violations cause the build to fail or just generate a report
+- ***failOnError*** - should violations cause the build to fail or just generate a report; if set to false, you may need to add the following to prevent your build still failing from Android Lint errors:
+
+    <details open>
+    <summary><b>groovy</b></summary>
+
+    ```
+    android {
+        lintOptions {
+            abortOnError false
+        }
+    }
+    ```
+    
+    </details>
+    
+    <details open>
+    <summary><b>kotlin</b></summary>
+
+    ```
+    android {
+        lintOptions {
+            abortOnError = false
+        }
+    }
+    ```
+    
+    </details>
+
 - ***checkstyle*** - block to customize the checkstyle reporter
   - ***enabled*** - set if checkstyle should execute
   - ***reporterConfig*** - provide a custom [checkstyle config](http://checkstyle.sourceforge.net/config.html)

--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ gnag {
     
     </details>
     
-    <details open>
+    <details>
     <summary><b>kotlin</b></summary>
 
     ```
     android {
         lintOptions {
-            abortOnError = false
+            abortOnError(false)
         }
     }
     ```


### PR DESCRIPTION
I observed that my build would still fail due to errors from Android Lint even if I set `failOnError` to `false` for gnag. To fix this, I needed to specify `abortOnError false` for Android LintOptions. I've updated the README to indicate this.

Please confirm that my Kotlin syntax is correct, or make any necessary changes. Thanks!