### PR TITLE
Update checkers

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -41,13 +41,13 @@ dependencies {
     compile 'com.vladsch.flexmark:flexmark-all:0.34.4'
 
     // Built in checks
-    compile('com.puppycrawl.tools:checkstyle:8.16') {
+    compile('com.puppycrawl.tools:checkstyle:8.18') {
         // See discussion here: https://github.com/btkelly/gnag/issues/196
         exclude group: 'net.sf.saxon', module: 'Saxon-HE'
     }
 
     compile 'com.google.code.findbugs:findbugs:3.0.1'
-    compile 'net.sourceforge.pmd:pmd-java:6.10.0'
+    compile 'net.sourceforge.pmd:pmd-java:6.12.0'
 
     // Testing
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/plugin/src/main/resources/pmd.xml
+++ b/plugin/src/main/resources/pmd.xml
@@ -23,100 +23,69 @@
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
-  <description>Gnag default PMD rules</description>
+    <description>Gnag default PMD rules</description>
 
-  <rule ref="rulesets/java/android.xml"/>
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="AvoidReassigningParameters"/>
+        <exclude name="GuardLogStatement"/>
+        <exclude name="LooseCoupling"/>
+        <exclude name="SwitchStmtsShouldHaveDefault"/>
+    </rule>
 
-  <rule ref="rulesets/java/basic.xml"/>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="AbstractNaming"/>
+        <exclude name="AtLeastOneConstructor"/>
+        <exclude name="AvoidFinalLocalVariable"/>
+        <exclude name="AvoidPrefixingMethodParameters"/>
+        <exclude name="ConfusingTernary"/>
+        <exclude name="DefaultPackage"/>
+        <exclude name="LocalVariableCouldBeFinal"/>
+        <exclude name="LongVariable"/>
+        <exclude name="MethodArgumentCouldBeFinal"/>
+        <exclude name="OnlyOneReturn"/>
+        <exclude name="ShortClassName"/>
+        <exclude name="ShortMethodName"/>
+        <exclude name="ShortVariable"/>
+    </rule>
 
-  <rule ref="rulesets/java/braces.xml"/>
+    <rule ref="category/java/design.xml">
+        <exclude name="ExcessiveImports"/>
+        <exclude name="LawOfDemeter"/>
+        <exclude name="TooManyFields"/>
+    </rule>
 
-  <rule ref="rulesets/java/clone.xml"/>
+    <rule ref="category/java/documentation.xml">
+        <exclude name="CommentRequired"/>
+        <exclude name="CommentSize"/>
+    </rule>
 
-  <rule ref="rulesets/java/codesize.xml">
-    <exclude name="TooManyFields"/>
-  </rule>
-  <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
-    <properties>
-      <property name="reportLevel" value="20"/>
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/codesize.xml/TooManyMethods">
-    <properties>
-      <property name="maxmethods" value="25"/>
-    </properties>
-  </rule>
+    <rule ref="category/java/errorprone.xml">
+        <exclude name="AssignmentInOperand"/>
+        <exclude name="AvoidLiteralsInIfCondition"/>
+        <exclude name="DataflowAnomalyAnalysis"/>
+        <exclude name="NullAssignment"/>
+    </rule>
 
-  <rule ref="rulesets/java/comments.xml">
-    <exclude name="CommentRequired"/>
-    <exclude name="CommentSize"/>
-  </rule>
+    <rule ref="category/java/multithreading.xml"/>
 
-  <rule ref="rulesets/java/controversial.xml">
-    <!-- while ((x = update()) != null) { process(x); } -->
-    <exclude name="AssignmentInOperand"/>
-    <exclude name="AtLeastOneConstructor"/>
-    <exclude name="AvoidFinalLocalVariable"/>
-    <exclude name="AvoidLiteralsInIfCondition"/>
-    <exclude name="AvoidPrefixingMethodParameters"/>
-    <exclude name="DataflowAnomalyAnalysis"/>
-    <exclude name="NullAssignment"/>
-    <exclude name="OnlyOneReturn"/>
-    <exclude name="DefaultPackage"/>
-  </rule>
+    <rule ref="category/java/performance.xml">
+        <exclude name="AvoidInstantiatingObjectsInLoops"/>
+        <!-- Android listeners contain a lot of such switch statements -->
+        <exclude name="TooFewBranchesForASwitchStatement"/>
+    </rule>
 
-  <rule ref="rulesets/java/coupling.xml">
-    <exclude name="ExcessiveImports"/>
-    <exclude name="LawOfDemeter"/>
-  </rule>
+    <rule ref="category/java/security.xml"/>
 
-  <rule ref="rulesets/java/design.xml">
-    <exclude name="AvoidReassigningParameters"/>
-    <!-- if (x != y) { short code block } else { long code block } -->
-    <exclude name="ConfusingTernary"/>
-    <exclude name="SwitchStmtsShouldHaveDefault"/>
-    <!-- Android listeners contain a lot of such switch statements -->
-    <exclude name="TooFewBranchesForASwitchStatement"/>
-  </rule>
+      <rule ref="category/java/design.xml/CyclomaticComplexity">
+        <properties>
+          <property name="reportLevel" value="20"/>
+        </properties>
+      </rule>
 
-  <rule ref="rulesets/java/empty.xml"/>
-
-  <rule ref="rulesets/java/finalizers.xml"/>
-
-  <rule ref="rulesets/java/imports.xml"/>
-
-  <rule ref="rulesets/java/junit.xml"/>
-
-  <rule ref="rulesets/java/logging-jakarta-commons.xml">
-    <exclude name="GuardLogStatement"/>
-  </rule>
-
-  <rule ref="rulesets/java/migrating.xml"/>
-
-  <rule ref="rulesets/java/naming.xml">
-    <exclude name="AbstractNaming"/>
-    <exclude name="LongVariable"/>
-    <exclude name="ShortClassName"/>
-    <exclude name="ShortVariable"/>
-    <exclude name="ShortMethodName"/>
-  </rule>
-
-  <rule ref="rulesets/java/optimizations.xml">
-    <exclude name="AvoidInstantiatingObjectsInLoops"/>
-    <exclude name="LocalVariableCouldBeFinal"/>
-    <exclude name="MethodArgumentCouldBeFinal"/>
-  </rule>
-
-  <rule ref="rulesets/java/strictexception.xml"/>
-
-  <rule ref="rulesets/java/strings.xml"/>
-
-  <rule ref="rulesets/java/typeresolution.xml">
-    <exclude name="LooseCoupling"/>
-  </rule>
-
-  <rule ref="rulesets/java/unnecessary.xml"/>
-
-  <rule ref="rulesets/java/unusedcode.xml"/>
+      <rule ref="category/java/design.xml/TooManyMethods">
+        <properties>
+          <property name="maxmethods" value="25"/>
+        </properties>
+      </rule>
 
 </ruleset>

--- a/plugin/src/main/resources/pmd.xml
+++ b/plugin/src/main/resources/pmd.xml
@@ -18,12 +18,12 @@
 -->
 
 <!-- Custom PMD config-->
-<ruleset name="ruleset"
+<ruleset name="Gnag default PMD rules"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
-  <description>POM rule set file</description>
+  <description>Gnag default PMD rules</description>
 
   <rule ref="rulesets/java/android.xml"/>
 

--- a/plugin/src/main/resources/pmd.xml
+++ b/plugin/src/main/resources/pmd.xml
@@ -18,10 +18,10 @@
 -->
 
 <!-- Custom PMD config-->
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="ruleset"
-  xmlns="http://pmd.sf.net/ruleset/1.0.0"
-  xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd"
-  xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
+<ruleset name="ruleset"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
   <description>POM rule set file</description>
 

--- a/plugin/src/main/resources/pmd.xml
+++ b/plugin/src/main/resources/pmd.xml
@@ -79,7 +79,8 @@
 
       <rule ref="category/java/design.xml/CyclomaticComplexity">
         <properties>
-          <property name="reportLevel" value="20"/>
+          <property name="classReportLevel" value="20"/>
+          <property name="methodReportLevel" value="20"/>
         </properties>
       </rule>
 

--- a/plugin/src/main/resources/pmd.xml
+++ b/plugin/src/main/resources/pmd.xml
@@ -51,6 +51,7 @@
     <rule ref="category/java/design.xml">
         <exclude name="ExcessiveImports"/>
         <exclude name="LawOfDemeter"/>
+        <exclude name="LoosePackageCoupling"/>
         <exclude name="TooManyFields"/>
     </rule>
 


### PR DESCRIPTION
**Changes**

- Updates Checkstyle (minor version) and PMD (patch version).
- Fixes #214.
- Fixes some misc. small issues with the default configuration file (misconfigured rule; rule configured using deprecated property names).

**Testing**

- Modify `./buildAndRunJavaKotlinExample.sh` by adding the `--info` flag: `./gradlew clean gnagCheck --info`.
- Run `./buildAndRunJavaKotlinExample.sh`

On master: see multiple warnings of the form

    The RuleSet rulesets/java/naming.xml has been deprecated and will be removed in PMD 7.0.0

and multiple warnings of the form

    Use Rule name category/java/design.xml/UselessOverridingMethod instead of the deprecated Rule name rulesets/java/unnecessary.xml/UselessOverridingMethod. PMD 7.0.0 will remove support for this deprecated Rule name usage.

and the specific warning

    Removed misconfigured rule: LoosePackageCoupling  cause: No packages or classes specified

and the specific warning

    Rule CyclomaticComplexity uses deprecated property 'reportLevel'. Future versions of PMD will remove support for this property. Please use 'methodReportLevel' and 'classReportLevel' instead!

On this branch: see none of the above warnings:

On master: see PMD violations in the generated report file.
On this branch: see at least the same PMD violations as on master (plus some new ones for this sample!)

|Before|After (new violations annotated)|
|-|-|
|<img width="1417" alt="Screen Shot 2019-04-02 at 2 02 24 PM" src="https://user-images.githubusercontent.com/6463980/55426069-dd98c780-5551-11e9-8287-c0016f351018.png">|<img width="1418" alt="Screen Shot 2019-04-02 at 2 02 58 PM" src="https://user-images.githubusercontent.com/6463980/55426070-dd98c780-5551-11e9-8cb7-244f34e686b2.png">|



