### PR TITLE
Updated to allow AndroidLintViolatorDetector to make case insensitive comparisons of the levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ gnag {
   - ***reporterConfig*** - provide a custom [detekt config](https://arturbosch.github.io/detekt/configurations.html)
 - ***androidLint*** - block to customize the android lint reporter
   - ***enabled*** - set if the android lint reporter should look for a lint report
-  - ***severity*** - can be 'Error' or 'Warning' depending on which severity you want Gnag to check
+  - ***severity*** - can be 'Error' or 'Warning' (case insensitive) depending on which severity you want Gnag to check
 - ***github*** - block to customize GitHub reporting (only used during the `gnagReport` task
   - ***rootUrl*** - root URL to use when communicating with the GitHub API (must include trailing slash), if not provided will default to "https://api.github.com/repos/"
   - ***repoName*** - account and repo name to report violations to

--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/AndroidLintViolationDetector.groovy
@@ -111,10 +111,10 @@ class AndroidLintViolationDetector extends BaseViolationDetector {
     }
 
     private boolean severityEnabled(final String severity) {
-        if (androidLintExtension.severity.equals(SEVERITY_WARNING)) {
+        if (androidLintExtension.severity.equalsIgnoreCase(SEVERITY_WARNING)) {
             return true
         } else {
-            return severity.equals(SEVERITY_ERROR)
+            return severity.equalsIgnoreCase(SEVERITY_ERROR)
         }
     }
 


### PR DESCRIPTION
Fixes #225 

This PR updated the AndroidLintViolatorDetectors to make case insensitive comparisons of the Severity levels so that the case of the severity levels will not matter to gnag.

Also updated the documentation to call put this change.