### PR TITLE
Switching over to using Open JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ cache:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
 jdk:
-  - oraclejdk8
+  - openjdk8
 language: groovy
 branches:
   only:
   - master
-dist: trusty # https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/8

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ android:
   - build-tools-25.0.3
   - android-25
 jdk:
-  - oraclejdk8
+  - openjdk8
 branches:
   only:
   - master


### PR DESCRIPTION
Fixes #228 

This PR switched over to using open jdk's jdk version vs the oracle ones because oracle is moving to licensing java.

Some information regarding this can be found [here](https://www.itassetmanagement.net/2019/02/21/oracle-java-new-licensing-model/)


