### PR TITLE
Provide configuration option to override version of detekt

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,37 +90,38 @@ In this example the issue number and authtoken for the comment user are passed a
 gnag {
     enabled true
     failOnError true
-    
+
     checkstyle {
         enabled true
         reporterConfig project.file('config/checkstyle.xml')
     }
-    
+
     pmd {
         enabled true
         reporterConfig project.file('config/pmd.xml')
     }
-    
+
     findbugs {
         enabled true
         reporterConfig project.file('config/findbugs.xml')
     }
-    
+
     ktlint {
         enabled true
         toolVersion "0.24.0"
     }
-    
+
     detekt {
         enabled true
         reporterConfig project.file('config/detekt.yml')
+        toolVersion "1.0.1"
     }
-    
+
     androidLint {
         enabled true
         severity 'Error'
     }
-    
+
     github {
         rootUrl 'https://my.githubinstall.com/repos/'
         repoName 'btkelly/repo'
@@ -202,9 +203,9 @@ gnag {
         }
     }
     ```
-    
+
     </details>
-    
+
     <details>
     <summary><b>kotlin</b></summary>
 
@@ -215,7 +216,7 @@ gnag {
         }
     }
     ```
-    
+
     </details>
 
 - ***checkstyle*** - block to customize the checkstyle reporter
@@ -233,6 +234,7 @@ gnag {
 - ***detekt*** - block to customize the detekt reporter
   - ***enabled*** - set if detekt should execute
   - ***reporterConfig*** - provide a custom [detekt config](https://arturbosch.github.io/detekt/configurations.html)
+  - ***toolVersion*** - override the detekt version compiled into Gnag
 - ***androidLint*** - block to customize the android lint reporter
   - ***enabled*** - set if the android lint reporter should look for a lint report
   - ***severity*** - can be 'Error' or 'Warning' (case insensitive) depending on which severity you want Gnag to check

--- a/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/GnagPlugin.groovy
@@ -43,9 +43,6 @@ class GnagPlugin implements Plugin<Project> {
         project.repositories.jcenter()
         // Unlikely to be missing in real projects; here for sample projects only.
 
-        project.configurations.create("gnagDetekt")
-        project.dependencies.add("gnagDetekt", "io.gitlab.arturbosch.detekt:detekt-cli:1.0.0.RC7-3")
-
         project.afterEvaluate { evaluatedProject ->
             ProjectHelper projectHelper = new ProjectHelper(evaluatedProject)
 

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
@@ -101,6 +101,12 @@ public class GnagCheckTask extends DefaultTask {
     }
 
     if (gnagPluginExtension.detekt.isEnabled() && projectHelper.hasKotlinSourceFiles()) {
+      String overrideToolVersion = gnagPluginExtension.detekt.getToolVersion();
+      String toolVersion = overrideToolVersion != null ? overrideToolVersion : "1.0.1";
+
+      project.getConfigurations().create("gnagDetekt");
+      project.getDependencies().add("gnagDetekt", "io.gitlab.arturbosch.detekt:detekt-cli:" + toolVersion);
+
       Task detektTask = DetektTask
           .addTask(projectHelper, gnagPluginExtension.detekt.getReporterConfig());
       gnagCheckTask.dependsOn(detektTask);


### PR DESCRIPTION
This adds an option to the Gnag configuration block that allows overriding the version of `detekt` used by Gnag:

```groovy
gnag {
    enabled true
    failOnError true

    detekt {
        enabled true
        toolVersion "1.0.1"
    }
}
```