### PR TITLE
Updated versions of Ktlint, pmd and gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ gnag {
     
     ktlint {
         enabled true
-        toolVersion "0.24.0"
+        toolVersion "0.35.0"
     }
     
     detekt {
@@ -160,7 +160,7 @@ gnag {
 
     ktlint {
         isEnabled = true
-        toolVersion("0.24.0")
+        toolVersion("0.35.0")
     }
 
     detekt {

--- a/example-android-kts/gradle/wrapper/gradle-wrapper.properties
+++ b/example-android-kts/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example-android/app/build.gradle
+++ b/example-android/app/build.gradle
@@ -47,8 +47,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    testImplementation 'junit:junit:4.12'
 }
 
 license {

--- a/example-android/gradle/wrapper/gradle-wrapper.properties
+++ b/example-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example-java-kotlin-kts/build.gradle.kts
+++ b/example-java-kotlin-kts/build.gradle.kts
@@ -23,8 +23,8 @@ repositories {
 }
 
 dependencies {
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11")
-    testCompile(group = "junit", name = "junit", version = "4.12")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11")
+    testImplementation(group = "junit", name = "junit", version = "4.12")
 }
 
 license {

--- a/example-java-kotlin-kts/gradle/wrapper/gradle-wrapper.properties
+++ b/example-java-kotlin-kts/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example-java-kotlin/build.gradle
+++ b/example-java-kotlin/build.gradle
@@ -29,8 +29,8 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11"
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11"
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 license {

--- a/example-java-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/example-java-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/bintray.gradle
+++ b/plugin/bintray.gradle
@@ -4,6 +4,16 @@ javadoc {
     failOnError = false
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 publishing {
     publications {
         GnagPublication(MavenPublication) {
@@ -35,16 +45,6 @@ bintray {
             released  = new Date()
         }
     }
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
 }
 
 task createClasspathManifest {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     }
 
     compile 'com.google.code.findbugs:findbugs:3.0.1'
-    compile 'net.sourceforge.pmd:pmd-java:6.12.0'
+    compile 'net.sourceforge.pmd:pmd-java:6.18.0'
 
     // Testing
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
@@ -89,10 +89,10 @@ public class GnagCheckTask extends DefaultTask {
 
     if (gnagPluginExtension.ktlint.isEnabled() && projectHelper.hasKotlinSourceFiles()) {
       String overrideToolVersion = gnagPluginExtension.ktlint.getToolVersion();
-      String toolVersion = overrideToolVersion != null ? overrideToolVersion : "0.24.0";
+      String toolVersion = overrideToolVersion != null ? overrideToolVersion : "0.35.0";
 
       project.getConfigurations().create("gnagKtlint");
-      project.getDependencies().add("gnagKtlint", "com.github.shyiko:ktlint:" + toolVersion);
+      project.getDependencies().add("gnagKtlint", "com.pinterest:ktlint:" + toolVersion);
 
       Task ktlintTask = KtlintTask.addTask(projectHelper);
       gnagCheckTask.dependsOn(ktlintTask);

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/KtlintTask.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/KtlintTask.groovy
@@ -30,7 +30,7 @@ final class KtlintTask {
         taskOptions.put(Task.TASK_DESCRIPTION, "Runs ktlint and generates an XML report for parsing by Gnag")
 
         return projectHelper.project.task(taskOptions, "gnagKtlint") { task ->
-            main = "com.github.shyiko.ktlint.Main"
+            main = "com.pinterest.ktlint.Main"
             classpath = projectHelper.project.configurations.gnagKtlint
             ignoreExitValue = true
             args "--reporter=checkstyle,output=${projectHelper.getKtlintReportFile()}"

--- a/plugin/src/main/groovy/com/btkelly/gnag/utils/ProjectHelper.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/utils/ProjectHelper.groovy
@@ -29,11 +29,11 @@ class ProjectHelper {
         this.project = project
     }
 
-    public Project getProject() {
+    Project getProject() {
         return project
     }
 
-    public boolean isAndroidProject() {
+    boolean isAndroidProject() {
         return project.getExtensions().findByName("android") != null
     }
 
@@ -41,34 +41,34 @@ class ProjectHelper {
         return getSourceFilesWithSuffices(["java"] as String[])
     }
 
-    public boolean hasJavaSourceFiles() {
+    boolean hasJavaSourceFiles() {
         return !getJavaSourceFiles().isEmpty()
     }
 
-    public List<File> getKotlinSourceFiles() {
+    List<File> getKotlinSourceFiles() {
         return getSourceFilesWithSuffices(["kt", "kts"] as String[])
     }
 
-    public boolean hasKotlinSourceFiles() {
+    boolean hasKotlinSourceFiles() {
         return !getKotlinSourceFiles().isEmpty()
     }
 
-    public File getReportsDir() {
+    File getReportsDir() {
         File reportsDir = new File(project.buildDir.path + "/outputs/gnag/")
         reportsDir.mkdirs()
         return reportsDir
     }
 
-    public File getKtlintReportFile() {
+    File getKtlintReportFile() {
         return new File(getReportsDir(), "ktlint_report.xml")
     }
 
-    public String getDetektReportFileName() {
+    String getDetektReportFileName() {
         return "detekt_report"
     }
 
     private Collection<File> getSourceFilesWithSuffices(final String[] suffices) {
-        final Collection<File> allSourceFiles
+        Collection<File> allSourceFiles
 
         if (isAndroidProject()) {
             allSourceFiles = project.android.sourceSets.inject([]) { files, sourceSet ->


### PR DESCRIPTION
1. Updated the version of Ktlint to 0.35.0. This included renaming the 
[main package name](https://github.com/pinterest/ktlint/commit/a29bee62477219e42b4adc7472ed67292995f104)

2. Updated the version of pmd to 6.12.0. (There are a bunch of warning with this update that call out deprecations that will be removed in the next major version of pmd)

3. Updated the version of gradle to 5.6.3. 
- Re ordered some tasks in the bintray.gradle file
- Changed `classifier` -> `archiveClassifier` (because the former was deprecated)
- Removed the `public` modifier from the `ProjectHelper.groovy` class because it was redundant.
- Updated the version of gradle in all the examples and removed `compile` and `testCompile` in favor of `implementation` and `testImplementation` in the `build.gradle` files in all the examples

4. Updated the main README to specify the latest version of ktlint.

Verified that all the example tasks run and fail because of gnag violations.