### PR TITLE
Update version of Detekt and fix a reporting bug

### DIFF
--- a/plugin/src/main/groovy/com/btkelly/gnag/reporters/DetektViolationDetector.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/reporters/DetektViolationDetector.groovy
@@ -47,7 +47,7 @@ class DetektViolationDetector extends BaseViolationDetector {
 
     @Override
     File reportFile() {
-        return new File(projectHelper.getReportsDir(), "${projectHelper.getDetektReportFileName()}.xml")
+        return new File(projectHelper.getReportsDir(), "${projectHelper.getDetektReportFileName()}")
     }
 
 }

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/DetektTask.groovy
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/DetektTask.groovy
@@ -37,9 +37,8 @@ final class DetektTask {
             main = "io.gitlab.arturbosch.detekt.cli.Main"
             classpath = projectHelper.project.configurations.gnagDetekt
             ignoreExitValue = true
+            args "--report", "xml:${projectHelper.getReportsDir()}/${projectHelper.getDetektReportFileName()}"
             args "--input", "${projectHelper.kotlinSourceFiles.join(',')}"
-            args "--output", "${projectHelper.getReportsDir()}"
-            args "--output-name", "${projectHelper.getDetektReportFileName()}"
 
             if (reporterConfig != null) {
                 args "--config", "$reporterConfig"

--- a/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
+++ b/plugin/src/main/groovy/com/btkelly/gnag/tasks/GnagCheckTask.java
@@ -102,7 +102,7 @@ public class GnagCheckTask extends DefaultTask {
 
     if (gnagPluginExtension.detekt.isEnabled() && projectHelper.hasKotlinSourceFiles()) {
       String overrideToolVersion = gnagPluginExtension.detekt.getToolVersion();
-      String toolVersion = overrideToolVersion != null ? overrideToolVersion : "1.0.1";
+      String toolVersion = overrideToolVersion != null ? overrideToolVersion : "1.1.1";
 
       project.getConfigurations().create("gnagDetekt");
       project.getDependencies().add("gnagDetekt", "io.gitlab.arturbosch.detekt:detekt-cli:" + toolVersion);


### PR DESCRIPTION
1. Updated the version of detekt from 1.0.1-> 1.1.1

2. Updated to use the `--report` flag instead of the `--output-name` & `--output` to provide an argument for the name of the output file. This created a `detekt_report` file without the `xml` extension in the gnag folder that is in xml format because we specify as the report id in the `--report` argument.

Reference: https://arturbosch.github.io/detekt/cli.html